### PR TITLE
Clean up for PTC reader attribute types

### DIFF
--- a/src/lib/io/PTC.cpp
+++ b/src/lib/io/PTC.cpp
@@ -150,8 +150,11 @@ ParticlesDataMutable* readPTC(const char* filename,const bool headersOnly)
 
         int dataSize=0;
         ParticleAttributeType dataType;
-        if(typeName=="color" || typeName=="vector" || typeName=="point" || typeName=="color"){
+        if(typeName=="normal" || typeName=="vector" || typeName=="point"){
             dataType=VECTOR;
+            dataSize=3;
+        }else if(typeName=="color"){
+            dataType=FLOAT;
             dataSize=3;
         }else if(typeName=="matrix"){
             dataType=FLOAT;


### PR DESCRIPTION
"color" was mentioned twice here, while "normal" was not mentioned.  This is fixed, and the "color" type is recorded as FLOAT data rather than VECTOR data.  This makes ptc->geo->ptc idempotent when starting with 3 channel FLOAT data which seems like a desirable property, though I'm not entirely sure it's the right thing to do, discussion welcome.
