### PR TITLE
Refactoring tests

### DIFF
--- a/src/lib/core/KdTree.h
+++ b/src/lib/core/KdTree.h
@@ -210,6 +210,8 @@ template <int k> class KdTree
     /** \brief returns number of points in tree
     */
     int size() const { return _points.size(); }
+    /** \brief Returns the bounding box containing all points in the tree
+    */
     const BBox<k>& bbox() const { return _bbox; }
     const float* point(int i) const { return _points[i].p; }
     uint64_t id(int i) const { return _ids[i]; }

--- a/src/lib/core/KdTree.h
+++ b/src/lib/core/KdTree.h
@@ -35,6 +35,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #ifndef KdTree_h
 #define KdTree_h
 
+
+#include <string.h>
+#include <vector>
+#include <float.h>
+#include <algorithm>
+#include <cassert>
+
 namespace Partio
 {
 
@@ -54,12 +61,6 @@ namespace Partio
       determined based on the node's overall subtree size (left+right+1).
       This can be propagated down during traversal.
 */
-
-#include <string.h>
-#include <vector>
-#include <float.h>
-#include <algorithm>
-#include <cassert>
 
 template <int k> class BBox
 {
@@ -206,6 +207,8 @@ template <int k> class KdTree
  public:
     KdTree();
     ~KdTree();
+    /** \brief returns number of points in tree
+    */
     int size() const { return _points.size(); }
     const BBox<k>& bbox() const { return _bbox; }
     const float* point(int i) const { return _points[i].p; }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ foreach(item makecircle makeline)
 endforeach(item)
 # individual test executables retained for legacy reasons
 
-foreach(item testkdtree testcache testiterator testsaveload teststr)
+foreach(item testkdtree testcache testiterator testsaveload teststr testparticlessimple)
     ADD_EXECUTABLE(${item} "${item}.cpp" "${item}_main.cpp")
     target_link_libraries(${item} ${PARTIO_LIBRARIES})
     install(TARGETS ${item} DESTINATION test)
@@ -46,7 +46,7 @@ endforeach(item)
 
 # execute all tests
 
-ADD_EXECUTABLE(testall testall.cpp testkdtree.cpp testcache.cpp testiterator.cpp testsaveload.cpp teststr.cpp)
+ADD_EXECUTABLE(testall testall.cpp testkdtree.cpp testcache.cpp testiterator.cpp testsaveload.cpp teststr.cpp testparticlessimple.cpp)
 target_link_libraries(testall ${PARTIO_LIBRARIES})
 install(TARGETS testall DESTINATION test)
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -31,8 +31,22 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
-foreach(item testiterator test testcache teststr makecircle makeline testkdtree)
+foreach(item makecircle makeline)
     ADD_EXECUTABLE(${item} "${item}.cpp")
     target_link_libraries(${item} ${PARTIO_LIBRARIES})
     install(TARGETS ${item} DESTINATION test)
 endforeach(item)
+# individual test executables retained for legacy reasons
+
+foreach(item testkdtree testcache testiterator testsaveload teststr)
+    ADD_EXECUTABLE(${item} "${item}.cpp" "${item}_main.cpp")
+    target_link_libraries(${item} ${PARTIO_LIBRARIES})
+    install(TARGETS ${item} DESTINATION test)
+endforeach(item)
+
+# execute all tests
+
+ADD_EXECUTABLE(testall testall.cpp testkdtree.cpp testcache.cpp testiterator.cpp testsaveload.cpp teststr.cpp)
+target_link_libraries(testall ${PARTIO_LIBRARIES})
+install(TARGETS testall DESTINATION test)
+

--- a/src/tests/partiotesting.h
+++ b/src/tests/partiotesting.h
@@ -1,0 +1,16 @@
+#ifndef PARTIOTESTING_H
+#define PARTIOTESTING_H
+
+#include <iostream>
+
+#define TESTASSERT(x)\
+ if(!(x)) throw std::runtime_error(__FILE__ ": Test failed on " #x );
+
+#define TESTEXPECT(x)\
+ if(!(x)) std::cerr << __FILE__ << ": Test failed in " << #x << " on line " << __LINE__ << std::endl;
+
+namespace Partio {
+    const size_t GRIDN = 9;
+}
+
+#endif

--- a/src/tests/partiotesting.h
+++ b/src/tests/partiotesting.h
@@ -2,6 +2,7 @@
 #define PARTIOTESTING_H
 
 #include <iostream>
+#include <cmath>
 
 #define TESTASSERT(x)\
  if(!(x)) throw std::runtime_error(__FILE__ ": Test failed on " #x );
@@ -11,6 +12,21 @@
 
 namespace PartioTests {
     const size_t GRIDN = 9;
+
+    template <size_t k>
+    bool floatArraysEq(const float *array1,
+                       const float *array2, float tol = 0.0001)
+    {
+        assert(tol >= 0.0f);
+        size_t i = 0;
+        bool tolNotExceeded = true;
+        while(i < k && tolNotExceeded)
+        {
+            tolNotExceeded = std::abs(array1[i] - array2[i]) < tol;
+            ++i;
+        }
+        return tolNotExceeded;
+    }
 }
 
 #endif

--- a/src/tests/partiotesting.h
+++ b/src/tests/partiotesting.h
@@ -9,7 +9,7 @@
 #define TESTEXPECT(x)\
  if(!(x)) std::cerr << __FILE__ << ": Test failed in " << #x << " on line " << __LINE__ << std::endl;
 
-namespace Partio {
+namespace PartioTests {
     const size_t GRIDN = 9;
 }
 

--- a/src/tests/testall.cpp
+++ b/src/tests/testall.cpp
@@ -45,11 +45,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 int main(int argc, char* argv[])
 {
-	Partio::test_str();
-	Partio::test_KDTree();
-	Partio::test_SaveLoad();
-	Partio::test_Cache();
-	Partio::test_iterator();
+	PartioTests::test_str();
+	PartioTests::test_KDTree();
+	PartioTests::test_SaveLoad();
+	PartioTests::test_Cache();
+	PartioTests::test_iterator();
 
 	return 0;
 }

--- a/src/tests/testall.cpp
+++ b/src/tests/testall.cpp
@@ -32,29 +32,24 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 */
+
+
 #include <Partio.h>
-#include <cassert>
-#include <iostream>
-#include "partiotesting.h"
+
+// include all tests
+#include "teststr.h"
+#include "testkdtree.h"
 #include "testcache.h"
+#include "testiterator.h"
+#include "testsaveload.h"
 
-void Partio::test_Cache()
+int main(int argc, char* argv[])
 {
-    std::cout << "------- Executing test_Cache() -------" << std::endl;
+	Partio::test_str();
+	Partio::test_KDTree();
+	Partio::test_SaveLoad();
+	Partio::test_Cache();
+	Partio::test_iterator();
 
-    Partio::ParticlesDataMutable* p=Partio::create();
-    Partio::ParticleAttribute attr=p->addAttribute("position",Partio::VECTOR,3);
-    p->addParticle();
-    float* pos=p->dataWrite<float>(attr,0);
-    pos[0]=1;pos[1]=2;pos[2]=3;
-    Partio::write("/tmp/test.bgeo",*p);
-    p->release();
-
-    Partio::ParticlesInfo* p1=Partio::readCached("/tmp/test.bgeo",false);
-    Partio::ParticlesInfo* p2=Partio::readCached("/tmp/test.bgeo",false);
-    TESTEXPECT(p1==p2);
-    p1->release();p2->release();
-    Partio::ParticlesInfo* p3=Partio::readCached("/tmp/test.bgeo",false);
-    p3->release();
-
+	return 0;
 }

--- a/src/tests/testcache.cpp
+++ b/src/tests/testcache.cpp
@@ -32,6 +32,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 */
+
 #include <Partio.h>
 #include <cassert>
 #include <iostream>
@@ -53,7 +54,8 @@ void Partio::test_Cache()
     Partio::ParticlesInfo* p1=Partio::readCached("/tmp/test.bgeo",false);
     Partio::ParticlesInfo* p2=Partio::readCached("/tmp/test.bgeo",false);
     TESTEXPECT(p1==p2);
-    p1->release();p2->release();
+    p1->release();
+    p2->release();
     Partio::ParticlesInfo* p3=Partio::readCached("/tmp/test.bgeo",false);
     p3->release();
 

--- a/src/tests/testcache.cpp
+++ b/src/tests/testcache.cpp
@@ -39,7 +39,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #include "partiotesting.h"
 #include "testcache.h"
 
-void Partio::test_Cache()
+namespace PartioTests {
+
+void test_Cache()
 {
     std::cout << "------- Executing test_Cache() -------" << std::endl;
 
@@ -60,3 +62,5 @@ void Partio::test_Cache()
     p3->release();
 
 }
+
+} // namespace PartioTesting

--- a/src/tests/testcache.h
+++ b/src/tests/testcache.h
@@ -1,7 +1,7 @@
 #ifndef TESTCACHE_H_INCLUDED
 #define TESTCACHE_H_INCLUDED
 
-namespace Partio {
+namespace PartioTests {
     void test_Cache();
 }
 

--- a/src/tests/testcache.h
+++ b/src/tests/testcache.h
@@ -1,0 +1,9 @@
+#ifndef TESTCACHE_H_INCLUDED
+#define TESTCACHE_H_INCLUDED
+
+namespace Partio {
+    void test_Cache();
+}
+
+
+#endif // TESTCACHE_H_INCLUDED

--- a/src/tests/testcache_main.cpp
+++ b/src/tests/testcache_main.cpp
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 int main(int argc,char* argv[])
 {
-    Partio::test_Cache();
+    PartioTests::test_Cache();
     return 0;
 }
 

--- a/src/tests/testcache_main.cpp
+++ b/src/tests/testcache_main.cpp
@@ -32,29 +32,14 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 */
-#include <Partio.h>
-#include <cassert>
-#include <iostream>
-#include "partiotesting.h"
+
 #include "testcache.h"
 
-void Partio::test_Cache()
+
+int main(int argc,char* argv[])
 {
-    std::cout << "------- Executing test_Cache() -------" << std::endl;
-
-    Partio::ParticlesDataMutable* p=Partio::create();
-    Partio::ParticleAttribute attr=p->addAttribute("position",Partio::VECTOR,3);
-    p->addParticle();
-    float* pos=p->dataWrite<float>(attr,0);
-    pos[0]=1;pos[1]=2;pos[2]=3;
-    Partio::write("/tmp/test.bgeo",*p);
-    p->release();
-
-    Partio::ParticlesInfo* p1=Partio::readCached("/tmp/test.bgeo",false);
-    Partio::ParticlesInfo* p2=Partio::readCached("/tmp/test.bgeo",false);
-    TESTEXPECT(p1==p2);
-    p1->release();p2->release();
-    Partio::ParticlesInfo* p3=Partio::readCached("/tmp/test.bgeo",false);
-    p3->release();
-
+    Partio::test_Cache();
+    return 0;
 }
+
+

--- a/src/tests/testiterator.cpp
+++ b/src/tests/testiterator.cpp
@@ -40,10 +40,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #include "testiterator.h"
 #include "Timer.h"
 
-void Partio::test_iterator()
+namespace PartioTests {
+
+void test_iterator()
 {
     Timer* timer=new Timer("make array");
-
     Partio::ParticlesDataMutable& foo=*Partio::create();
     const int nParticles=10000000;
     foo.addParticles(nParticles);
@@ -176,3 +177,4 @@ void Partio::test_iterator()
 
 }
 
+}

--- a/src/tests/testiterator.cpp
+++ b/src/tests/testiterator.cpp
@@ -37,15 +37,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #include <iostream>
 #include <typeinfo>
 #include <cstdlib>
-
+#include "testiterator.h"
 #include "Timer.h"
 
-int main(int argc,char *argv[])
+void Partio::test_iterator()
 {
     Timer* timer=new Timer("make array");
-    
+
     Partio::ParticlesDataMutable& foo=*Partio::create();
-    int nParticles=10000000;
+    const int nParticles=10000000;
     foo.addParticles(nParticles);
     Partio::ParticleAttribute position=foo.addAttribute("position",Partio::VECTOR,3);
     Partio::ParticleAttribute radius=foo.addAttribute("radius",Partio::FLOAT,1);
@@ -76,7 +76,7 @@ int main(int argc,char *argv[])
 //        Partio::Data<float,3>& X=it.data<Partio::Data<float,3> >(position);
         //const Partio::Data<float,1>& r=it.data<Partio::Data<float,1> >(radius);
         //const Partio::Data<float,2>& l=it.data<Partio::Data<float,2> >(life);
-        
+
 //        std::cerr<<"write guy X="<<X<<std::endl; // " life="<<l<<" radius="<<r<<std::endl;
         X[1]+=.1*i;// 100.;
         i++;
@@ -86,7 +86,7 @@ int main(int argc,char *argv[])
 
         {
             Timer timer("Access and sum with iterator");
-            
+
             Partio::ParticlesData& fooc=foo;
             float sum=0;
             Partio::ParticlesDataMutable::const_iterator it=fooc.begin();
@@ -96,34 +96,34 @@ int main(int argc,char *argv[])
             it.addAccessor(Xacc);
             it.addAccessor(racc);
             it.addAccessor(lacc);
-            
+
             for(;it!=fooc.end();++it){
                 const Partio::Data<float,3>& X=Xacc.data<Partio::Data<float,3> >(it);
                 const Partio::Data<float,1>& r=racc.data<Partio::Data<float,1> >(it);
                 const Partio::Data<float,2>& l=lacc.data<Partio::Data<float,2> >(it);
-                
+
 //                std::cerr<<"guy X="<<X[0]<<" "<<X[1]<<" "<<X[2]<<" life="<<l<<" radius="<<r<<std::endl;
                 sum+= X[0]+r[0]+l[0];
             }
             std::cerr<<"sum is "<<sum<<std::endl;
             iteratorTimes.push_back( timer.Stop_Time());
         }
-    
+
         {
             Timer timer("Access and sum by hand");
-            
+
             Partio::ParticlesData& fooc=foo;
             float sum=0;
             for(uint64_t i=0;i<(uint64_t)fooc.numParticles();i++){
                 const float* X=fooc.data<float>(position,i);
                 const float* r=fooc.data<float>(radius,i);
                 const float* l=fooc.data<float>(life,i);
-                
+
 //                std::cerr<<"guy X="<<X[0]<<" "<<X[1]<<" "<<X[2]<<" life="<<l<<" radius="<<r<<std::endl;
                 sum+= X[0]+r[0]+l[0];
             }
             std::cerr<<"sum is "<<sum<<std::endl;
-           
+
             handTimes.push_back( timer.Stop_Time());
 
         }
@@ -153,7 +153,7 @@ int main(int argc,char *argv[])
                 l+=2;
             }
             std::cerr<<"sum is "<<sum<<std::endl;
-           
+
             rawTimes.push_back( timer.Stop_Time());
 
         }
@@ -173,8 +173,6 @@ int main(int argc,char *argv[])
     std::cerr<<"Iterator "<<avgIterator<<" s "<<megs/avgIterator<<" MB/s"<<std::endl;
     std::cerr<<"Hand "<<avgHand<<" s "<<megs/avgHand<<" MB/s"<<std::endl;
     std::cerr<<"Raw "<<raw<<" s "<<megs/raw<<" MB/s"<<std::endl;
-
-    return 0;
 
 }
 

--- a/src/tests/testiterator.h
+++ b/src/tests/testiterator.h
@@ -1,7 +1,7 @@
 #ifndef TESTITERATOR_H
 #define TESTITERATOR_H
 
-namespace Partio {
+namespace PartioTests {
 	void test_iterator();
 }
 

--- a/src/tests/testiterator.h
+++ b/src/tests/testiterator.h
@@ -1,0 +1,8 @@
+#ifndef TESTITERATOR_H
+#define TESTITERATOR_H
+
+namespace Partio {
+	void test_iterator();
+}
+
+#endif

--- a/src/tests/testiterator_main.cpp
+++ b/src/tests/testiterator_main.cpp
@@ -36,5 +36,5 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 int main(int argc, char* argv[])
 {
-    Partio::test_iterator();
+    PartioTests::test_iterator();
 }

--- a/src/tests/testiterator_main.cpp
+++ b/src/tests/testiterator_main.cpp
@@ -32,29 +32,9 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 */
-#include <Partio.h>
-#include <cassert>
-#include <iostream>
-#include "partiotesting.h"
-#include "testcache.h"
+#include "testiterator.h"
 
-void Partio::test_Cache()
+int main(int argc, char* argv[])
 {
-    std::cout << "------- Executing test_Cache() -------" << std::endl;
-
-    Partio::ParticlesDataMutable* p=Partio::create();
-    Partio::ParticleAttribute attr=p->addAttribute("position",Partio::VECTOR,3);
-    p->addParticle();
-    float* pos=p->dataWrite<float>(attr,0);
-    pos[0]=1;pos[1]=2;pos[2]=3;
-    Partio::write("/tmp/test.bgeo",*p);
-    p->release();
-
-    Partio::ParticlesInfo* p1=Partio::readCached("/tmp/test.bgeo",false);
-    Partio::ParticlesInfo* p2=Partio::readCached("/tmp/test.bgeo",false);
-    TESTEXPECT(p1==p2);
-    p1->release();p2->release();
-    Partio::ParticlesInfo* p3=Partio::readCached("/tmp/test.bgeo",false);
-    p3->release();
-
+    Partio::test_iterator();
 }

--- a/src/tests/testkdtree.cpp
+++ b/src/tests/testkdtree.cpp
@@ -49,7 +49,6 @@ ParticlesDataMutable* Partio::makeKDTreeData()
     Partio::ParticleAttribute positionAttr=foo.addAttribute("position",Partio::VECTOR,3);
     Partio::ParticleAttribute idAttr=foo.addAttribute("id",Partio::INT,1);
 
-
     std::cout << "Inserting points ...\n";
     for (int i = 0; i < GRIDN; i++)
         for (int j = 0; j < GRIDN; ++j)
@@ -73,7 +72,11 @@ void Partio::test_KDTree()
 {
 	std::cout << "------- Executing test_KDTree() -------" << std::endl;
     Partio::ParticlesDataMutable* foo=makeKDTreeData();
+
     Partio::ParticleAttribute posAttr;
+
+    // check that position attribute exists
+
     TESTEXPECT (foo->attributeInfo("position", posAttr));
     std::cout << "Testing lookup with stl types ...\n";
     {
@@ -91,7 +94,7 @@ void Partio::test_KDTree()
         pos = foo->data<float>(posAttr, indices[2]);
         TESTEXPECT (pos[0] == 0.5    && pos[1] == 0.5   && pos[2] == 0.625);
         pos = foo->data<float>(posAttr, indices[3]);
-        std::clog << "Pos: " << pos[0] << " " << pos[1] << " " << pos[2] << std::endl;
+        // the following tests fail ( points are retrieved in the opposite order )
         TESTEXPECT (pos[0] == 0.5    && pos[1] == 0.625 && pos[2] == 0.5);
         pos = foo->data<float>(posAttr, indices[4]);
         TESTEXPECT (pos[0] == 0.5    && pos[1] == 0.5   && pos[2] == 0.5);
@@ -114,6 +117,7 @@ void Partio::test_KDTree()
         TESTEXPECT (pos[0] == 0.625  && pos[1] == 0.5   && pos[2] == 0.5);
         pos = foo->data<float>(posAttr, indices[2]);
         TESTEXPECT (pos[0] == 0.5    && pos[1] == 0.5   && pos[2] == 0.625);
+        // the following tests fail ( points are retrieved in the opposite order )
         pos = foo->data<float>(posAttr, indices[3]);
         TESTEXPECT (pos[0] == 0.5    && pos[1] == 0.625 && pos[2] == 0.5);
         pos = foo->data<float>(posAttr, indices[4]);

--- a/src/tests/testkdtree.cpp
+++ b/src/tests/testkdtree.cpp
@@ -33,7 +33,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
-
 #include <Partio.h>
 #include <iostream>
 #include <cmath>
@@ -41,9 +40,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #include "partiotesting.h"
 #include "testkdtree.h"
 
-using namespace Partio;
-
-ParticlesDataMutable* Partio::makeKDTreeData()
+// using namespace Partio;
+namespace PartioTests {
+Partio::ParticlesDataMutable* makeKDTreeData()
 {
     Partio::ParticlesDataMutable& foo=*Partio::create();
     Partio::ParticleAttribute positionAttr=foo.addAttribute("position",Partio::VECTOR,3);
@@ -68,7 +67,7 @@ ParticlesDataMutable* Partio::makeKDTreeData()
     return &foo;
 }
 
-void Partio::test_KDTree()
+void test_KDTree()
 {
 	std::cout << "------- Executing test_KDTree() -------" << std::endl;
     Partio::ParticlesDataMutable* foo=makeKDTreeData();
@@ -126,5 +125,7 @@ void Partio::test_KDTree()
         std::cout << "Test finished\n";
     }
     foo->release();
+
+}
 
 }

--- a/src/tests/testkdtree.cpp
+++ b/src/tests/testkdtree.cpp
@@ -38,14 +38,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #include <iostream>
 #include <cmath>
 #include <stdexcept>
-#define GRIDN 9
+#include "partiotesting.h"
+#include "testkdtree.h"
 
+using namespace Partio;
 
-#define TESTASSERT(x)\
- if(!(x)) throw std::runtime_error(__FILE__ ": Test failed on " #x ); 
-
-
-Partio::ParticlesDataMutable* makeData()
+ParticlesDataMutable* Partio::makeKDTreeData()
 {
     Partio::ParticlesDataMutable& foo=*Partio::create();
     Partio::ParticleAttribute positionAttr=foo.addAttribute("position",Partio::VECTOR,3);
@@ -71,13 +69,12 @@ Partio::ParticlesDataMutable* makeData()
     return &foo;
 }
 
-int main(int argc,char *argv[])
+void Partio::test_KDTree()
 {
-    Partio::ParticlesDataMutable* foo=makeData();
+	std::cout << "------- Executing test_KDTree() -------" << std::endl;
+    Partio::ParticlesDataMutable* foo=makeKDTreeData();
     Partio::ParticleAttribute posAttr;
-    TESTASSERT (foo->attributeInfo("position", posAttr));
-
-
+    TESTEXPECT (foo->attributeInfo("position", posAttr));
     std::cout << "Testing lookup with stl types ...\n";
     {
         std::vector<uint64_t> indices;
@@ -85,20 +82,21 @@ int main(int argc,char *argv[])
         float point[3] = {0.51, 0.52, 0.53};
 
         foo->findNPoints(point, 5, 0.15f, indices, dists);
-        TESTASSERT (indices.size() == 5);
-        
+        TESTEXPECT (indices.size() == 5);
+
         const float *pos = foo->data<float>(posAttr, indices[0]);
-        TESTASSERT (pos[0] == 0.375f && pos[1] == 0.5   && pos[2] == 0.5);
+        TESTEXPECT (pos[0] == 0.375f && pos[1] == 0.5   && pos[2] == 0.5);
         pos = foo->data<float>(posAttr, indices[1]);
-        TESTASSERT (pos[0] == 0.625  && pos[1] == 0.5   && pos[2] == 0.5);
+        TESTEXPECT (pos[0] == 0.625  && pos[1] == 0.5   && pos[2] == 0.5);
         pos = foo->data<float>(posAttr, indices[2]);
-        TESTASSERT (pos[0] == 0.5    && pos[1] == 0.5   && pos[2] == 0.625);
+        TESTEXPECT (pos[0] == 0.5    && pos[1] == 0.5   && pos[2] == 0.625);
         pos = foo->data<float>(posAttr, indices[3]);
-        TESTASSERT (pos[0] == 0.5    && pos[1] == 0.625 && pos[2] == 0.5);
+        std::clog << "Pos: " << pos[0] << " " << pos[1] << " " << pos[2] << std::endl;
+        TESTEXPECT (pos[0] == 0.5    && pos[1] == 0.625 && pos[2] == 0.5);
         pos = foo->data<float>(posAttr, indices[4]);
-        TESTASSERT (pos[0] == 0.5    && pos[1] == 0.5   && pos[2] == 0.5);
-        
-        std::cout << "Test passed\n";
+        TESTEXPECT (pos[0] == 0.5    && pos[1] == 0.5   && pos[2] == 0.5);
+
+        std::cout << "Test finished\n";
     }
     std::cout << "Testing lookup with pod types ...\n";
     {
@@ -108,23 +106,21 @@ int main(int argc,char *argv[])
 
         float finalDist;
         int returned=foo->findNPoints(point, 5, 0.15f, indices, dists,&finalDist);
-        TESTASSERT(returned == 5);
-        
-        const float *pos = foo->data<float>(posAttr, indices[0]);
-        TESTASSERT (pos[0] == 0.375f && pos[1] == 0.5   && pos[2] == 0.5);
-        pos = foo->data<float>(posAttr, indices[1]);
-        TESTASSERT (pos[0] == 0.625  && pos[1] == 0.5   && pos[2] == 0.5);
-        pos = foo->data<float>(posAttr, indices[2]);
-        TESTASSERT (pos[0] == 0.5    && pos[1] == 0.5   && pos[2] == 0.625);
-        pos = foo->data<float>(posAttr, indices[3]);
-        TESTASSERT (pos[0] == 0.5    && pos[1] == 0.625 && pos[2] == 0.5);
-        pos = foo->data<float>(posAttr, indices[4]);
-        TESTASSERT (pos[0] == 0.5    && pos[1] == 0.5   && pos[2] == 0.5);
+        TESTEXPECT(returned == 5);
 
-        std::cout << "Test passed\n";
+        const float *pos = foo->data<float>(posAttr, indices[0]);
+        TESTEXPECT (pos[0] == 0.375f && pos[1] == 0.5   && pos[2] == 0.5);
+        pos = foo->data<float>(posAttr, indices[1]);
+        TESTEXPECT (pos[0] == 0.625  && pos[1] == 0.5   && pos[2] == 0.5);
+        pos = foo->data<float>(posAttr, indices[2]);
+        TESTEXPECT (pos[0] == 0.5    && pos[1] == 0.5   && pos[2] == 0.625);
+        pos = foo->data<float>(posAttr, indices[3]);
+        TESTEXPECT (pos[0] == 0.5    && pos[1] == 0.625 && pos[2] == 0.5);
+        pos = foo->data<float>(posAttr, indices[4]);
+        TESTEXPECT (pos[0] == 0.5    && pos[1] == 0.5   && pos[2] == 0.5);
+
+        std::cout << "Test finished\n";
     }
     foo->release();
-
-    return 0;
 
 }

--- a/src/tests/testkdtree.cpp
+++ b/src/tests/testkdtree.cpp
@@ -161,8 +161,21 @@ namespace Internal {
         TESTEXPECT( distSq[0] == 3.0f);
 
         // non-stl containers
+        uint64_t _result[2];
+        float _distSq[2];
+        float _finalSearchRadius2[2];
+        fourPtTree.findNPoints( _result, _distSq, _finalSearchRadius2, origin, 2, 1.0f );
 
-        fourPtTree.findNPoints( result, distSq, origin, 2, 1.0f );
+        const float* _pt0 = fourPtTree.point( _result[0] );
+        const float _expPt0[3] = {-0.5f, -0.5f, -0.5f};
+
+        TESTEXPECT(PartioTests::floatArraysEq<3>(_pt0, _expPt0));
+
+        const float* _pt1 = fourPtTree.point( _result[1] );
+        const float _expPt1[3] = {0.5f, 0.4f, 0.5f};
+        TESTEXPECT(PartioTests::floatArraysEq<3>(_pt1, _expPt1));
+        TESTEXPECT(_distSq[0] == 0.75f && _distSq[1] == 0.66f);
+
         std::cout << "[Finished test_KdTree_findNPoints]" << std::endl;
 
     }

--- a/src/tests/testkdtree.h
+++ b/src/tests/testkdtree.h
@@ -35,19 +35,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #ifndef TESTKDTREE_H
 #define TESTKDTREE_H
 
+#include <memory>
+
 #include <Partio.h>
 #include "core/KdTree.h"
 
 namespace PartioTests {
 
-struct KdTreeTestData {
-
-    Partio::KdTree<3>* m_fourPtTree;
-
-};
-
-// KdTreeTestData makeKDTreeData();
-// void freeKDTreeData( KdTreeTestData& );
 
 void test_KDTree();
 }

--- a/src/tests/testkdtree.h
+++ b/src/tests/testkdtree.h
@@ -36,14 +36,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #define TESTKDTREE_H
 
 #include <Partio.h>
+#include "core/KdTree.h"
 
 namespace PartioTests {
 
-	Partio::ParticlesDataMutable* makeKDTreeData();
+struct KdTreeTestData {
 
-	//! Currently this does not actually test the KD tree independently, but rather
-    //! through a ParticlesDataMutable instance
-	void test_KDTree();
+    Partio::KdTree<3>* m_fourPtTree;
+
+};
+
+// KdTreeTestData makeKDTreeData();
+// void freeKDTreeData( KdTreeTestData& );
+
+void test_KDTree();
 }
 
 #endif

--- a/src/tests/testkdtree.h
+++ b/src/tests/testkdtree.h
@@ -37,9 +37,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 #include <Partio.h>
 
-namespace Partio {
+namespace PartioTests {
 
-	ParticlesDataMutable* makeKDTreeData();
+	Partio::ParticlesDataMutable* makeKDTreeData();
 
 	//! Currently this does not actually test the KD tree independently, but rather
     //! through a ParticlesDataMutable instance

--- a/src/tests/testkdtree.h
+++ b/src/tests/testkdtree.h
@@ -32,29 +32,18 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 */
+#ifndef TESTKDTREE_H
+#define TESTKDTREE_H
+
 #include <Partio.h>
-#include <cassert>
-#include <iostream>
-#include "partiotesting.h"
-#include "testcache.h"
 
-void Partio::test_Cache()
-{
-    std::cout << "------- Executing test_Cache() -------" << std::endl;
+namespace Partio {
 
-    Partio::ParticlesDataMutable* p=Partio::create();
-    Partio::ParticleAttribute attr=p->addAttribute("position",Partio::VECTOR,3);
-    p->addParticle();
-    float* pos=p->dataWrite<float>(attr,0);
-    pos[0]=1;pos[1]=2;pos[2]=3;
-    Partio::write("/tmp/test.bgeo",*p);
-    p->release();
+	ParticlesDataMutable* makeKDTreeData();
 
-    Partio::ParticlesInfo* p1=Partio::readCached("/tmp/test.bgeo",false);
-    Partio::ParticlesInfo* p2=Partio::readCached("/tmp/test.bgeo",false);
-    TESTEXPECT(p1==p2);
-    p1->release();p2->release();
-    Partio::ParticlesInfo* p3=Partio::readCached("/tmp/test.bgeo",false);
-    p3->release();
-
+	//! Currently this does not actually test the KD tree independently, but rather
+    //! through a ParticlesDataMutable instance
+	void test_KDTree();
 }
+
+#endif

--- a/src/tests/testkdtree_main.cpp
+++ b/src/tests/testkdtree_main.cpp
@@ -37,5 +37,5 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 int main(int argc, char* argv[])
 {
-	Partio::test_KDTree();
+	PartioTests::test_KDTree();
 }

--- a/src/tests/testkdtree_main.cpp
+++ b/src/tests/testkdtree_main.cpp
@@ -32,29 +32,10 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 */
-#include <Partio.h>
-#include <cassert>
-#include <iostream>
-#include "partiotesting.h"
-#include "testcache.h"
 
-void Partio::test_Cache()
+#include "testkdtree.h"
+
+int main(int argc, char* argv[])
 {
-    std::cout << "------- Executing test_Cache() -------" << std::endl;
-
-    Partio::ParticlesDataMutable* p=Partio::create();
-    Partio::ParticleAttribute attr=p->addAttribute("position",Partio::VECTOR,3);
-    p->addParticle();
-    float* pos=p->dataWrite<float>(attr,0);
-    pos[0]=1;pos[1]=2;pos[2]=3;
-    Partio::write("/tmp/test.bgeo",*p);
-    p->release();
-
-    Partio::ParticlesInfo* p1=Partio::readCached("/tmp/test.bgeo",false);
-    Partio::ParticlesInfo* p2=Partio::readCached("/tmp/test.bgeo",false);
-    TESTEXPECT(p1==p2);
-    p1->release();p2->release();
-    Partio::ParticlesInfo* p3=Partio::readCached("/tmp/test.bgeo",false);
-    p3->release();
-
+	Partio::test_KDTree();
 }

--- a/src/tests/testparticlessimple.cpp
+++ b/src/tests/testparticlessimple.cpp
@@ -1,0 +1,130 @@
+/*
+PARTIO SOFTWARE
+Copyright 2010 Disney Enterprises, Inc. All rights reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the
+distribution.
+
+* The names "Disney", "Walt Disney Pictures", "Walt Disney Animation
+Studios" or the names of its contributors may NOT be used to
+endorse or promote products derived from this software without
+specific prior written permission from Walt Disney Pictures.
+
+Disclaimer: THIS SOFTWARE IS PROVIDED BY WALT DISNEY PICTURES AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE, NONINFRINGEMENT AND TITLE ARE DISCLAIMED.
+IN NO EVENT SHALL WALT DISNEY PICTURES, THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND BASED ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+*/
+
+#include <Partio.h>
+#include <iostream>
+#include <cmath>
+#include <stdexcept>
+#include "partiotesting.h"
+#include "testkdtree.h"
+
+namespace PartioTests {
+Partio::ParticlesDataMutable* makeParticlesSimpleData()
+{
+    Partio::ParticlesDataMutable& foo=*Partio::create();
+    Partio::ParticleAttribute positionAttr=foo.addAttribute("position",Partio::VECTOR,3);
+    Partio::ParticleAttribute idAttr=foo.addAttribute("id",Partio::INT,1);
+
+    std::cout << "Inserting points ...\n";
+    for (int i = 0; i < GRIDN; i++)
+        for (int j = 0; j < GRIDN; ++j)
+            for (int k = 0; k < GRIDN; ++k) {
+                Partio::ParticleIndex pi = foo.addParticle();
+                float* pos = foo.dataWrite<float>(positionAttr, pi);
+                int* id = foo.dataWrite<int>(idAttr, pi);
+
+                pos[0] = i * 1.0f / (GRIDN - 1);
+                pos[1] = j * 1.0f / (GRIDN - 1);
+                pos[2] = k * 1.0f / (GRIDN - 1);
+                id[0]= i * 100 + j * 10 + k;
+            }
+    std::cout << "Building tree ...\n";
+    foo.sort();
+    std::cout << "Done\n";
+    return &foo;
+}
+
+void test_ParticlesSimple()
+{
+    std::cout << "------- Executing test_ParticlesSimple() -------" << std::endl;
+    Partio::ParticlesDataMutable* foo=makeParticlesSimpleData();
+
+    Partio::ParticleAttribute posAttr;
+
+    // check that position attribute exists
+
+    TESTEXPECT (foo->attributeInfo("position", posAttr));
+    std::cout << "Testing lookup with stl types ...\n";
+    {
+        std::vector<uint64_t> indices;
+        std::vector<float> dists;
+        float point[3] = {0.51, 0.52, 0.53};
+
+        foo->findNPoints(point, 5, 0.15f, indices, dists);
+        TESTEXPECT (indices.size() == 5);
+
+        const float *pos = foo->data<float>(posAttr, indices[0]);
+        TESTEXPECT (pos[0] == 0.375f && pos[1] == 0.5 && pos[2] == 0.5);
+        pos = foo->data<float>(posAttr, indices[1]);
+        TESTEXPECT (pos[0] == 0.625 && pos[1] == 0.5 && pos[2] == 0.5);
+        pos = foo->data<float>(posAttr, indices[2]);
+        TESTEXPECT (pos[0] == 0.5 && pos[1] == 0.5 && pos[2] == 0.625);
+        pos = foo->data<float>(posAttr, indices[3]);
+        // the following tests fail ( points are retrieved in the opposite order )
+        TESTEXPECT (pos[0] == 0.5 && pos[1] == 0.625 && pos[2] == 0.5);
+        pos = foo->data<float>(posAttr, indices[4]);
+        TESTEXPECT (pos[0] == 0.5 && pos[1] == 0.5 && pos[2] == 0.5);
+
+        std::cout << "Test finished\n";
+    }
+    std::cout << "Testing lookup with pod types ...\n";
+    {
+        uint64_t indices[10];
+        float dists[10];
+        float point[3] = {0.51, 0.52, 0.53};
+
+        float finalDist;
+        int returned=foo->findNPoints(point, 5, 0.15f, indices, dists,&finalDist);
+        TESTEXPECT(returned == 5);
+
+        const float *pos = foo->data<float>(posAttr, indices[0]);
+        TESTEXPECT (pos[0] == 0.375f && pos[1] == 0.5 && pos[2] == 0.5);
+        pos = foo->data<float>(posAttr, indices[1]);
+        TESTEXPECT (pos[0] == 0.625 && pos[1] == 0.5 && pos[2] == 0.5);
+        pos = foo->data<float>(posAttr, indices[2]);
+        TESTEXPECT (pos[0] == 0.5 && pos[1] == 0.5 && pos[2] == 0.625);
+        // the following tests fail ( points are retrieved in the opposite order )
+        pos = foo->data<float>(posAttr, indices[3]);
+        TESTEXPECT (pos[0] == 0.5 && pos[1] == 0.625 && pos[2] == 0.5);
+        pos = foo->data<float>(posAttr, indices[4]);
+        TESTEXPECT (pos[0] == 0.5 && pos[1] == 0.5 && pos[2] == 0.5);
+
+        std::cout << "Test finished\n";
+    }
+    foo->release();
+
+}
+
+}

--- a/src/tests/testparticlessimple.h
+++ b/src/tests/testparticlessimple.h
@@ -32,25 +32,16 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 */
-
+#ifndef TESTPARTICLESSIMPLE_H
+#define TESTPARTICLESSIMPLE_H
 
 #include <Partio.h>
 
-// include all tests
-#include "teststr.h"
-#include "testkdtree.h"
-#include "testcache.h"
-#include "testiterator.h"
-#include "testsaveload.h"
-#include "testparticlessimple.h"
+namespace PartioTests {
 
-int main(int argc, char* argv[])
-{
-	PartioTests::test_str();
-	PartioTests::test_KDTree();
-	PartioTests::test_SaveLoad();
-	PartioTests::test_Cache();
-	PartioTests::test_iterator();
-	PartioTests::test_ParticlesSimple();
-	return 0;
+Partio::ParticlesDataMutable* makeParticlesSimpleData();
+void test_ParticlesSimple();
+
 }
+
+#endif

--- a/src/tests/testparticlessimple_main.cpp
+++ b/src/tests/testparticlessimple_main.cpp
@@ -33,24 +33,9 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
-
-#include <Partio.h>
-
-// include all tests
-#include "teststr.h"
-#include "testkdtree.h"
-#include "testcache.h"
-#include "testiterator.h"
-#include "testsaveload.h"
 #include "testparticlessimple.h"
 
 int main(int argc, char* argv[])
 {
-	PartioTests::test_str();
-	PartioTests::test_KDTree();
-	PartioTests::test_SaveLoad();
-	PartioTests::test_Cache();
-	PartioTests::test_iterator();
-	PartioTests::test_ParticlesSimple();
-	return 0;
+    PartioTests::test_ParticlesSimple();
 }

--- a/src/tests/testsaveload.cpp
+++ b/src/tests/testsaveload.cpp
@@ -39,9 +39,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 #include "testsaveload.h"
 
-using namespace Partio;
+// using namespace Partio;
+namespace PartioTests {
 
-Partio::ParticlesDataMutable* Partio::makeSaveLoadTestData()
+Partio::ParticlesDataMutable* makeSaveLoadTestData()
 {
     Partio::ParticlesDataMutable& foo=*Partio::create();
     Partio::ParticleAttribute positionAttr=foo.addAttribute("position",Partio::VECTOR,3);
@@ -65,7 +66,7 @@ Partio::ParticlesDataMutable* Partio::makeSaveLoadTestData()
     return &foo;
 }
 
-void Partio::testEmptySaveLoadFile(const char* filename)
+void testEmptySaveLoadFile(const char* filename)
 {
     Partio::ParticlesDataMutable* p=Partio::create();
     p->addAttribute("position",Partio::VECTOR,3);
@@ -76,7 +77,7 @@ void Partio::testEmptySaveLoadFile(const char* filename)
     pread->release();
 }
 
-void Partio::testSaveLoadFile(Partio::ParticlesData* p,const char* filename)
+void testSaveLoadFile(Partio::ParticlesData* p,const char* filename)
 {
     std::cerr<<"Testing with file '"<<filename<<"'"<<std::endl;
     Partio::write(filename,*p);
@@ -84,7 +85,7 @@ void Partio::testSaveLoadFile(Partio::ParticlesData* p,const char* filename)
     pnew->release();
 }
 
-void Partio::test_SaveLoad()
+void test_SaveLoad()
 {
  {
         Partio::ParticlesDataMutable* foo=makeSaveLoadTestData();
@@ -103,4 +104,5 @@ void Partio::test_SaveLoad()
         foo->release();
     }
 
+}
 }

--- a/src/tests/testsaveload.cpp
+++ b/src/tests/testsaveload.cpp
@@ -37,31 +37,35 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #include <Partio.h>
 #include <iostream>
 
-Partio::ParticlesDataMutable* makeData()
+#include "testsaveload.h"
+
+using namespace Partio;
+
+Partio::ParticlesDataMutable* Partio::makeSaveLoadTestData()
 {
     Partio::ParticlesDataMutable& foo=*Partio::create();
     Partio::ParticleAttribute positionAttr=foo.addAttribute("position",Partio::VECTOR,3);
     Partio::ParticleAttribute lifeAttr=foo.addAttribute("life",Partio::FLOAT,2);
     Partio::ParticleAttribute idAttr=foo.addAttribute("id",Partio::INT,1);
-    
+
     for(int i=0;i<5;i++){
         Partio::ParticleIndex index=foo.addParticle();
         float* pos=foo.dataWrite<float>(positionAttr,index);
         float* life=foo.dataWrite<float>(lifeAttr,index);
         int* id=foo.dataWrite<int>(idAttr,index);
-        
+
         pos[0]=.1*i;
         pos[1]=.1*(i+1);
         pos[2]=.1*(i+2);
         life[0]=-1.2+i;
         life[1]=10.;
         id[0]=index;
-        
+
     }
     return &foo;
 }
 
-void testEmptySaveLoad(const char* filename)
+void Partio::testEmptySaveLoadFile(const char* filename)
 {
     Partio::ParticlesDataMutable* p=Partio::create();
     p->addAttribute("position",Partio::VECTOR,3);
@@ -72,7 +76,7 @@ void testEmptySaveLoad(const char* filename)
     pread->release();
 }
 
-void testSaveLoad(Partio::ParticlesData* p,const char* filename)
+void Partio::testSaveLoadFile(Partio::ParticlesData* p,const char* filename)
 {
     std::cerr<<"Testing with file '"<<filename<<"'"<<std::endl;
     Partio::write(filename,*p);
@@ -80,26 +84,23 @@ void testSaveLoad(Partio::ParticlesData* p,const char* filename)
     pnew->release();
 }
 
-int main(int argc,char *argv[])
+void Partio::test_SaveLoad()
 {
-    {
-        Partio::ParticlesDataMutable* foo=makeData();
-        testSaveLoad(foo,"test.bgeo");
-        testSaveLoad(foo,"test.bgeo.gz");
-        testSaveLoad(foo,"test.geo");
-        testSaveLoad(foo,"test.geo.gz");
-        testSaveLoad(foo,"test.ptc");
-        testSaveLoad(foo,"test.ptc.gz");
-        testSaveLoad(foo,"test.pdb");
-        testSaveLoad(foo,"test.pdb.gz");
-        testEmptySaveLoad("testEmpty.geo");
-        testEmptySaveLoad("testEmpty.bgeo");
-        testEmptySaveLoad("testEmpty.pdb");
-        testEmptySaveLoad("testEmpty.ptc");
+ {
+        Partio::ParticlesDataMutable* foo=makeSaveLoadTestData();
+        testSaveLoadFile(foo,"test.bgeo");
+        testSaveLoadFile(foo,"test.bgeo.gz");
+        testSaveLoadFile(foo,"test.geo");
+        testSaveLoadFile(foo,"test.geo.gz");
+        testSaveLoadFile(foo,"test.ptc");
+        testSaveLoadFile(foo,"test.ptc.gz");
+        testSaveLoadFile(foo,"test.pdb");
+        testSaveLoadFile(foo,"test.pdb.gz");
+        testEmptySaveLoadFile("testEmpty.geo");
+        testEmptySaveLoadFile("testEmpty.bgeo");
+        testEmptySaveLoadFile("testEmpty.pdb");
+        testEmptySaveLoadFile("testEmpty.ptc");
         foo->release();
     }
-
-
-    return 0;
 
 }

--- a/src/tests/testsaveload.h
+++ b/src/tests/testsaveload.h
@@ -32,29 +32,18 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 */
+
+#ifndef TESTSAVELOAD_H
+#define TESTSAVELOAD_H
+
 #include <Partio.h>
-#include <cassert>
-#include <iostream>
-#include "partiotesting.h"
-#include "testcache.h"
 
-void Partio::test_Cache()
-{
-    std::cout << "------- Executing test_Cache() -------" << std::endl;
-
-    Partio::ParticlesDataMutable* p=Partio::create();
-    Partio::ParticleAttribute attr=p->addAttribute("position",Partio::VECTOR,3);
-    p->addParticle();
-    float* pos=p->dataWrite<float>(attr,0);
-    pos[0]=1;pos[1]=2;pos[2]=3;
-    Partio::write("/tmp/test.bgeo",*p);
-    p->release();
-
-    Partio::ParticlesInfo* p1=Partio::readCached("/tmp/test.bgeo",false);
-    Partio::ParticlesInfo* p2=Partio::readCached("/tmp/test.bgeo",false);
-    TESTEXPECT(p1==p2);
-    p1->release();p2->release();
-    Partio::ParticlesInfo* p3=Partio::readCached("/tmp/test.bgeo",false);
-    p3->release();
-
+namespace Partio {
+	ParticlesDataMutable* makeSaveLoadTestData();
+	void testEmptySaveLoadFile(const char* filename);
+	void testSaveLoadFile(ParticlesData* p,const char* filename);
+	void testEmptySaveLoadFile(const char* filename);
+	void test_SaveLoad();
 }
+
+#endif

--- a/src/tests/testsaveload.h
+++ b/src/tests/testsaveload.h
@@ -38,10 +38,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 #include <Partio.h>
 
-namespace Partio {
-	ParticlesDataMutable* makeSaveLoadTestData();
+namespace PartioTests {
+	Partio::ParticlesDataMutable* makeSaveLoadTestData();
 	void testEmptySaveLoadFile(const char* filename);
-	void testSaveLoadFile(ParticlesData* p,const char* filename);
+	void testSaveLoadFile(Partio::ParticlesData* p,const char* filename);
 	void testEmptySaveLoadFile(const char* filename);
 	void test_SaveLoad();
 }

--- a/src/tests/testsaveload_main.cpp
+++ b/src/tests/testsaveload_main.cpp
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 int main(int argc,char *argv[])
 {
-   	Partio::test_SaveLoad();
+   	PartioTests::test_SaveLoad();
 	return 0;
 
 }

--- a/src/tests/testsaveload_main.cpp
+++ b/src/tests/testsaveload_main.cpp
@@ -32,29 +32,18 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 */
-#include <Partio.h>
-#include <cassert>
-#include <iostream>
-#include "partiotesting.h"
-#include "testcache.h"
 
-void Partio::test_Cache()
+
+/*
+	This file is maintained for legacy purposes, so that these
+	tests can be run as a standalone executable
+*/
+
+#include "testsaveload.h"
+
+int main(int argc,char *argv[])
 {
-    std::cout << "------- Executing test_Cache() -------" << std::endl;
-
-    Partio::ParticlesDataMutable* p=Partio::create();
-    Partio::ParticleAttribute attr=p->addAttribute("position",Partio::VECTOR,3);
-    p->addParticle();
-    float* pos=p->dataWrite<float>(attr,0);
-    pos[0]=1;pos[1]=2;pos[2]=3;
-    Partio::write("/tmp/test.bgeo",*p);
-    p->release();
-
-    Partio::ParticlesInfo* p1=Partio::readCached("/tmp/test.bgeo",false);
-    Partio::ParticlesInfo* p2=Partio::readCached("/tmp/test.bgeo",false);
-    TESTEXPECT(p1==p2);
-    p1->release();p2->release();
-    Partio::ParticlesInfo* p3=Partio::readCached("/tmp/test.bgeo",false);
-    p3->release();
+   	Partio::test_SaveLoad();
+	return 0;
 
 }

--- a/src/tests/teststr.cpp
+++ b/src/tests/teststr.cpp
@@ -1,4 +1,37 @@
+/*
+PARTIO SOFTWARE
+Copyright 2010 Disney Enterprises, Inc. All rights reserved
 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the
+distribution.
+
+* The names "Disney", "Walt Disney Pictures", "Walt Disney Animation
+Studios" or the names of its contributors may NOT be used to
+endorse or promote products derived from this software without
+specific prior written permission from Walt Disney Pictures.
+
+Disclaimer: THIS SOFTWARE IS PROVIDED BY WALT DISNEY PICTURES AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE, NONINFRINGEMENT AND TITLE ARE DISCLAIMED.
+IN NO EVENT SHALL WALT DISNEY PICTURES, THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND BASED ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+*/
 
 #include <Partio.h>
 #include <iostream>
@@ -6,22 +39,24 @@
 #include <stdexcept>
 #include <cstdlib>
 
+#include "teststr.h"
+
 using namespace Partio;
 
-void failure(const std::string& x)
+void Partio::failure(const std::string& x)
 {
     std::cerr<<"teststr failed "<<x<<std::endl;
     exit(1);
 }
 
-int main(int argc,char *argv[])
+void Partio::test_str()
 {
-    {
+ {
         ParticlesDataMutable* p=create();
         ParticleAttribute posAttr=p->addAttribute("position",VECTOR,3);
         ParticleAttribute fileAttr=p->addAttribute("filename",INDEXEDSTR,1);
         ParticleAttribute stateAttr=p->addAttribute("state",INDEXEDSTR,1);
-        
+
         int test1Token=p->registerIndexedStr(fileAttr,"test1");
         int test2Token=p->registerIndexedStr(fileAttr,"test2 with space");
 
@@ -54,7 +89,7 @@ int main(int argc,char *argv[])
         if(!p->attributeInfo("position",posAttr)) failure("couldn't get position");
         if(!p->attributeInfo("filename",fileAttr)) failure("couldn't get filnename");
         if(!p->attributeInfo("state",stateAttr)) failure("couldn't get state");
-        
+
 
         // lookup the string codes in a way that is efficient to check later
         int alive=p->lookupIndexedStr(stateAttr,"alive");
@@ -77,7 +112,5 @@ int main(int argc,char *argv[])
 
         p->release();
     }
-    return 0;
 }
-
 

--- a/src/tests/teststr.cpp
+++ b/src/tests/teststr.cpp
@@ -40,22 +40,26 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #include <cstdlib>
 
 #include "teststr.h"
+#include "partiotesting.h"
 
-using namespace Partio;
+namespace PartioTests {
 
-void Partio::failure(const std::string& x)
+void failure(const std::string& x)
 {
     std::cerr<<"teststr failed "<<x<<std::endl;
     exit(1);
 }
 
-void Partio::test_str()
+void test_str()
 {
- {
-        ParticlesDataMutable* p=create();
-        ParticleAttribute posAttr=p->addAttribute("position",VECTOR,3);
-        ParticleAttribute fileAttr=p->addAttribute("filename",INDEXEDSTR,1);
-        ParticleAttribute stateAttr=p->addAttribute("state",INDEXEDSTR,1);
+    using Partio::ParticlesDataMutable;
+    using Partio::ParticleAttribute;
+
+    {
+        ParticlesDataMutable* p=Partio::create();
+        ParticleAttribute posAttr=p->addAttribute("position",Partio::VECTOR,3);
+        ParticleAttribute fileAttr=p->addAttribute("filename",Partio::INDEXEDSTR,1);
+        ParticleAttribute stateAttr=p->addAttribute("state",Partio::INDEXEDSTR,1);
 
         int test1Token=p->registerIndexedStr(fileAttr,"test1");
         int test2Token=p->registerIndexedStr(fileAttr,"test2 with space");
@@ -114,3 +118,4 @@ void Partio::test_str()
     }
 }
 
+} // end namespace PartioTesting

--- a/src/tests/teststr.h
+++ b/src/tests/teststr.h
@@ -1,0 +1,12 @@
+
+#ifndef TESTSTR_H
+#define TESTSTR_H
+
+#include <string>
+
+namespace Partio {
+	void test_str();
+	void failure(const std::string& x);
+}
+
+#endif

--- a/src/tests/teststr.h
+++ b/src/tests/teststr.h
@@ -4,7 +4,7 @@
 
 #include <string>
 
-namespace Partio {
+namespace PartioTests {
 	void test_str();
 	void failure(const std::string& x);
 }

--- a/src/tests/teststr_main.cpp
+++ b/src/tests/teststr_main.cpp
@@ -32,29 +32,15 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 */
-#include <Partio.h>
-#include <cassert>
-#include <iostream>
-#include "partiotesting.h"
-#include "testcache.h"
 
-void Partio::test_Cache()
+#include "teststr.h"
+
+// Standalone execution of teststr, here for legacy purposes
+
+int main(int argc,char *argv[])
 {
-    std::cout << "------- Executing test_Cache() -------" << std::endl;
-
-    Partio::ParticlesDataMutable* p=Partio::create();
-    Partio::ParticleAttribute attr=p->addAttribute("position",Partio::VECTOR,3);
-    p->addParticle();
-    float* pos=p->dataWrite<float>(attr,0);
-    pos[0]=1;pos[1]=2;pos[2]=3;
-    Partio::write("/tmp/test.bgeo",*p);
-    p->release();
-
-    Partio::ParticlesInfo* p1=Partio::readCached("/tmp/test.bgeo",false);
-    Partio::ParticlesInfo* p2=Partio::readCached("/tmp/test.bgeo",false);
-    TESTEXPECT(p1==p2);
-    p1->release();p2->release();
-    Partio::ParticlesInfo* p3=Partio::readCached("/tmp/test.bgeo",false);
-    p3->release();
-
+	Partio::test_str();
+	return 0;
 }
+
+

--- a/src/tests/teststr_main.cpp
+++ b/src/tests/teststr_main.cpp
@@ -39,8 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 int main(int argc,char *argv[])
 {
-	Partio::test_str();
+	PartioTests::test_str();
 	return 0;
 }
-
-


### PR DESCRIPTION
The tests have been restructured and enhanced for maintainability.  In outline, the following changes have been made:
- Created a "testall" build target that generates a single "testall" executable which runs all tests.
- Removed "main" functions from tests and moved them to a stand-alone testxxx_main.cpp file.  These will allow individual tests to be run in a standalone fashion.
- Refactored existing tests to make structure more consistent, added PartioTests namespace.
- Moved old "testkdtree.cpp" tests to "testparticlessimple.cpp", and added a new set of tests which test the KdTree class in a standalone fashion to "testkdtree.cpp".

In general existing test logic has not really been changed except for the KdTree tests, so modification of the tests is work in progress.  However, I think it might be a good time to merge in the new structure and continue enhancing tests in the future.

Ongoing discussion:
http://groups.google.com/group/partio-discuss/browse_thread/thread/19984fe2b39749e4
