### PR TITLE
Fix windows warnings level 4

### DIFF
--- a/src/lib/core/KdTree.h
+++ b/src/lib/core/KdTree.h
@@ -211,7 +211,7 @@ template <int k> class KdTree
  public:
     KdTree();
     ~KdTree();
-    int size() const { return _points.size(); }
+    int size() const { return static_cast<int>(_points.size()); }
     const BBox<k>& bbox() const { return _bbox; }
     const float* point(int i) const { return _points[i].p; }
     uint64_t id(int i) const { return _ids[i]; }
@@ -229,7 +229,7 @@ template <int k> class KdTree
     struct ComparePointsById {
 	float* points;
 	ComparePointsById(float* p) : points(p) {}
-	bool operator() (int a, int b) { return points[a*k] < points[b*k]; }
+	bool operator() (uint64_t a, uint64_t b) { return points[a*k] < points[b*k]; }
     };
     void findPoints(std::vector<uint64_t>& result, const BBox<k>& bbox,
 		    int n, int size, int j) const;
@@ -307,7 +307,7 @@ void KdTree<k>::sort()
     _sorted = 1;
 
     // reorder ids to sort points
-    int np = _points.size();
+    int np = static_cast<int>(_points.size());
     if (!np) return;
     if (np > 1) sortSubtree(0, np, 0);
 

--- a/src/lib/core/KdTree.h
+++ b/src/lib/core/KdTree.h
@@ -314,7 +314,7 @@ void KdTree<k>::sort()
     // reorder points to match id order
     std::vector<Point> newpoints(np);
     for (int i = 0; i < np; i++)
-	newpoints[i] = _points[_ids[i]];
+	newpoints[i] = _points[static_cast<unsigned int>(_ids[i])];
     std::swap(_points, newpoints);
 }
 

--- a/src/lib/core/KdTree.h
+++ b/src/lib/core/KdTree.h
@@ -332,7 +332,14 @@ void KdTree<k>::sortSubtree(int n, int size, int j)
 
     // sort left and right subtrees using next discriminant
     if (left <= 1) return;
+#ifdef _MSC_VER  
+    #pragma warning (push)  
+    #pragma warning (disable : 4127)  // suppress the warning due to the constant k being tested at runtime, an alternative would be to specialize the template class for k = 0
+#endif  
     if (k > 1) j = (j+1)%k;
+#ifdef _MSC_VER  
+    #pragma warning (pop)  
+#endif  
     sortSubtree(n+1, left, j);
     if (right <= 1) return;
     sortSubtree(n+left+1, right, j);

--- a/src/lib/core/ParticleCaching.cpp
+++ b/src/lib/core/ParticleCaching.cpp
@@ -99,12 +99,12 @@ void freeCached(ParticlesData* particles)
     mutex.unlock();
 }
 
-void beginCachedAccess(ParticlesData* particles)
+void beginCachedAccess(ParticlesData*)
 {
     // TODO: for future use
 }
 
-void endCachedAccess(ParticlesData* particles)
+void endCachedAccess(ParticlesData*)
 {
     // TODO: for future use
 }

--- a/src/lib/core/ParticleHeaders.cpp
+++ b/src/lib/core/ParticleHeaders.cpp
@@ -65,7 +65,7 @@ numParticles() const
 int ParticleHeaders::
 numAttributes() const
 {
-    return attributes.size();
+    return static_cast<int>(attributes.size());
 }
 
 bool ParticleHeaders::
@@ -145,10 +145,10 @@ addAttribute(const char* attribute,ParticleAttributeType type,const int count)
     ParticleAttribute attr;
     attr.name=attribute;
     attr.type=type;
-    attr.attributeIndex=attributes.size(); //  all arrays separate so we don't use this here!
+    attr.attributeIndex=static_cast<int>(attributes.size()); //  all arrays separate so we don't use this here!
     attr.count=count;
     attributes.push_back(attr);
-    nameToAttribute[attribute]=attributes.size()-1;
+    nameToAttribute[attribute]=static_cast<int>(attributes.size()-1);
     return attr;
 }
 

--- a/src/lib/core/ParticleHeaders.cpp
+++ b/src/lib/core/ParticleHeaders.cpp
@@ -95,21 +95,21 @@ sort()
 
 
 int ParticleHeaders::
-registerIndexedStr(const ParticleAttribute& attribute,const char* str)
+registerIndexedStr(const ParticleAttribute&,const char*)
 {
     assert(false);
     return -1;
 }
 
 int ParticleHeaders::
-lookupIndexedStr(const ParticleAttribute& attribute,const char* str) const
+lookupIndexedStr(const ParticleAttribute&,const char*) const
 {
     assert(false);
     return -1;
 }
 
 const std::vector<std::string>& ParticleHeaders::
-indexedStrs(const ParticleAttribute& attr) const
+indexedStrs(const ParticleAttribute&) const
 {
     static std::vector<std::string> dummy;
     assert(false);
@@ -117,22 +117,21 @@ indexedStrs(const ParticleAttribute& attr) const
 }
 
 void ParticleHeaders::
-findPoints(const float bboxMin[3],const float bboxMax[3],std::vector<ParticleIndex>& points) const
+findPoints(const float[3],const float[3],std::vector<ParticleIndex>&) const
 {
     assert(false);
 }
 
 float ParticleHeaders::
-findNPoints(const float center[3],const int nPoints,const float maxRadius,std::vector<ParticleIndex>& points,
-    std::vector<float>& pointDistancesSquared) const
+findNPoints(const float[3],const int,const float,std::vector<ParticleIndex>&,std::vector<float>&) const
 {
     assert(false);
     return 0;
 }
 
 int ParticleHeaders::
-findNPoints(const float center[3],int nPoints,const float maxRadius, ParticleIndex *points,
-    float *pointDistancesSquared, float *finalRadius2) const
+findNPoints(const float[3],int,const float, ParticleIndex *,
+    float *, float *) const
 {
     assert(false);
     return 0;
@@ -168,22 +167,22 @@ addParticles(const int countToAdd)
 }
 
 void* ParticleHeaders::
-dataInternal(const ParticleAttribute& attribute,const ParticleIndex particleIndex) const
+dataInternal(const ParticleAttribute&,const ParticleIndex) const
 {
     assert(false);
     return 0;
 }
 
 void ParticleHeaders::
-dataInternalMultiple(const ParticleAttribute& attribute,const int indexCount,
-    const ParticleIndex* particleIndices,const bool sorted,char* values) const
+dataInternalMultiple(const ParticleAttribute&,const int,
+    const ParticleIndex*,const bool,char*) const
 {
     assert(false);
 }
 
 void ParticleHeaders::
-dataAsFloat(const ParticleAttribute& attribute,const int indexCount,
-    const ParticleIndex* particleIndices,const bool sorted,float* values) const
+dataAsFloat(const ParticleAttribute&,const int,
+    const ParticleIndex*,const bool,float*) const
 {
     assert(false);
 }

--- a/src/lib/core/ParticleSimple.cpp
+++ b/src/lib/core/ParticleSimple.cpp
@@ -267,14 +267,14 @@ setupIteratorNextBlock(Partio::ParticleIterator<true>& iterator) const
 
 
 void ParticlesSimple::
-setupAccessor(Partio::ParticleIterator<false>& iterator,ParticleAccessor& accessor)
+setupAccessor(Partio::ParticleIterator<false>&,ParticleAccessor& accessor)
 {
     accessor.stride=accessor.count*sizeof(float);
     accessor.basePointer=attributeData[accessor.attributeIndex];
 }
 
 void ParticlesSimple::
-setupAccessor(Partio::ParticleIterator<true>& iterator,ParticleAccessor& accessor) const
+setupAccessor(Partio::ParticleIterator<true>&,ParticleAccessor& accessor) const
 {
     accessor.stride=accessor.count*sizeof(float);
     accessor.basePointer=attributeData[accessor.attributeIndex];
@@ -289,7 +289,7 @@ dataInternal(const ParticleAttribute& attribute,const ParticleIndex particleInde
 
 void ParticlesSimple::
 dataInternalMultiple(const ParticleAttribute& attribute,const int indexCount,
-    const ParticleIndex* particleIndices,const bool sorted,char* values) const
+    const ParticleIndex* particleIndices,const bool,char* values) const
 {
     assert(attribute.attributeIndex>=0 && attribute.attributeIndex<(int)attributes.size());
 

--- a/src/lib/core/ParticleSimple.cpp
+++ b/src/lib/core/ParticleSimple.cpp
@@ -77,7 +77,7 @@ numParticles() const
 int ParticlesSimple::
 numAttributes() const
 {
-    return attributes.size();
+    return static_cast<int>(attributes.size());
 }
 
 bool ParticlesSimple::
@@ -136,11 +136,11 @@ findPoints(const float bboxMin[3],const float bboxMax[3],std::vector<ParticleInd
 
     BBox<3> box(bboxMin);box.grow(bboxMax);
 
-    int startIndex=points.size();
+    int startIndex=static_cast<int>(points.size());
     kdtree->findPoints(points,box);
     // remap points found in findPoints to original index space
     for(unsigned int i=startIndex;i<points.size();i++){
-        points[i]=kdtree->id(points[i]);
+        points[i]=kdtree->id(static_cast<int>(points[i]));
     }
 }
 
@@ -158,7 +158,7 @@ findNPoints(const float center[3],const int nPoints,const float maxRadius,std::v
     float maxDistance=kdtree->findNPoints(points,pointDistancesSquared,center,nPoints,maxRadius);
     // remap all points since findNPoints clears array
     for(unsigned int i=0;i<points.size();i++){
-        ParticleIndex index=kdtree->id(points[i]);
+        ParticleIndex index=kdtree->id(static_cast<int>(points[i]));
         points[i]=index;
     }
     return maxDistance;
@@ -176,7 +176,7 @@ findNPoints(const float center[3],int nPoints,const float maxRadius, ParticleInd
     int count = kdtree->findNPoints (points, pointDistancesSquared, finalRadius2, center, nPoints, maxRadius);
     // remap all points since findNPoints clears array
     for(int i=0; i < count; i++){
-        ParticleIndex index = kdtree->id(points[i]);
+        ParticleIndex index = kdtree->id(static_cast<int>(points[i]));
         points[i]=index;
     }
     return count;
@@ -193,10 +193,10 @@ addAttribute(const char* attribute,ParticleAttributeType type,const int count)
     ParticleAttribute attr;
     attr.name=attribute;
     attr.type=type;
-    attr.attributeIndex=attributes.size(); //  all arrays separate so we don't use this here!
+    attr.attributeIndex=static_cast<int>(attributes.size()); //  all arrays separate so we don't use this here!
     attr.count=count;
     attributes.push_back(attr);
-    nameToAttribute[attribute]=attributes.size()-1;
+    nameToAttribute[attribute]=static_cast<int>(attributes.size()-1);
 
     int stride=TypeSize(type)*count;
     attributeStrides.push_back(stride);
@@ -310,7 +310,7 @@ dataAsFloat(const ParticleAttribute& attribute,const int indexCount,
         char* attrrawbase=attributeData[attribute.attributeIndex];
         int* attrbase=(int*)attrrawbase;
         int count=attribute.count;
-        for(int i=0;i<indexCount;i++) for(int k=0;k<count;k++) values[i*count+k]=(int)attrbase[particleIndices[i]*count+k];
+        for(int i=0;i<indexCount;i++) for(int k=0;k<count;k++) values[i*count+k]=static_cast<float>(attrbase[particleIndices[i]*count+k]);
     }
 }
 
@@ -320,7 +320,7 @@ registerIndexedStr(const ParticleAttribute& attribute,const char* str)
     IndexedStrTable& table=attributeIndexedStrs[attribute.attributeIndex];
     std::map<std::string,int>::const_iterator it=table.stringToIndex.find(str);
     if(it!=table.stringToIndex.end()) return it->second;
-    int newIndex=table.strings.size();
+    int newIndex=static_cast<int>(table.strings.size());
     table.strings.push_back(str);
     table.stringToIndex[str]=newIndex;
     return newIndex;

--- a/src/lib/core/ParticleSimpleInterleave.cpp
+++ b/src/lib/core/ParticleSimpleInterleave.cpp
@@ -77,7 +77,7 @@ numParticles() const
 int ParticlesSimpleInterleave::
 numAttributes() const
 {
-    return attributes.size();
+    return static_cast<int>(attributes.size());
 }
 
 
@@ -183,10 +183,10 @@ addAttribute(const char* attribute,ParticleAttributeType type,const int count)
     ParticleAttribute attr;
     attr.name=attribute;
     attr.type=type;
-    attr.attributeIndex=attributes.size(); //  all arrays separate so we don't use this here!
+    attr.attributeIndex=static_cast<int>(attributes.size()); //  all arrays separate so we don't use this here!
     attr.count=count;
     attributes.push_back(attr);
-    nameToAttribute[attribute]=attributes.size()-1;
+    nameToAttribute[attribute]=static_cast<int>(attributes.size()-1);
 
     // repackage data for new attribute
     int oldStride=stride;
@@ -320,7 +320,7 @@ registerIndexedStr(const ParticleAttribute& attribute,const char* str)
     IndexedStrTable& table=attributeIndexedStrs[attribute.attributeIndex];
     std::map<std::string,int>::const_iterator it=table.stringToIndex.find(str);
     if(it!=table.stringToIndex.end()) return it->second;
-    int newIndex=table.strings.size();
+    int newIndex=static_cast<int>(table.strings.size());
     table.strings.push_back(str);
     table.stringToIndex[str]=newIndex;
     return newIndex;

--- a/src/lib/core/ParticleSimpleInterleave.cpp
+++ b/src/lib/core/ParticleSimpleInterleave.cpp
@@ -128,7 +128,7 @@ sort()
 }
 
 void ParticlesSimpleInterleave::
-findPoints(const float bboxMin[3],const float bboxMax[3],std::vector<ParticleIndex>& points) const
+findPoints(const float[3],const float[3],std::vector<ParticleIndex>&) const
 {
 #if 0
     if(!kdtree){
@@ -146,8 +146,8 @@ findPoints(const float bboxMin[3],const float bboxMax[3],std::vector<ParticleInd
 }
 
 float ParticlesSimpleInterleave::
-findNPoints(const float center[3],const int nPoints,const float maxRadius,std::vector<ParticleIndex>& points,
-    std::vector<float>& pointDistancesSquared) const
+findNPoints(const float[3],const int,const float,std::vector<ParticleIndex>&,
+    std::vector<float>&) const
 {
 #if 0
     if(!kdtree){
@@ -164,8 +164,8 @@ findNPoints(const float center[3],const int nPoints,const float maxRadius,std::v
 }
 
 int ParticlesSimpleInterleave::
-findNPoints(const float center[3],int nPoints,const float maxRadius, ParticleIndex *points,
-    float *pointDistancesSquared, float *finalRadius2) const
+findNPoints(const float[3], int, const float, ParticleIndex *,
+    float *, float *) const
 {
     // TODO: I guess they don't support this lookup here
     return 0;
@@ -262,14 +262,14 @@ setupIteratorNextBlock(Partio::ParticleIterator<true>& iterator) const
 }
 
 void ParticlesSimpleInterleave::
-setupAccessor(Partio::ParticleIterator<false>& iterator,ParticleAccessor& accessor)
+setupAccessor(Partio::ParticleIterator<false>&,ParticleAccessor& accessor)
 {
     accessor.stride=stride;
     accessor.basePointer=data+attributeOffsets[accessor.attributeIndex];
 }
 
 void ParticlesSimpleInterleave::
-setupAccessor(Partio::ParticleIterator<true>& iterator,ParticleAccessor& accessor) const
+setupAccessor(Partio::ParticleIterator<true>&,ParticleAccessor& accessor) const
 {
     accessor.stride=stride;
     accessor.basePointer=data+attributeOffsets[accessor.attributeIndex];
@@ -283,8 +283,7 @@ dataInternal(const ParticleAttribute& attribute,const ParticleIndex particleInde
 }
 
 void ParticlesSimpleInterleave::
-dataInternalMultiple(const ParticleAttribute& attribute,const int indexCount,
-    const ParticleIndex* particleIndices,const bool sorted,char* values) const
+dataInternalMultiple(const ParticleAttribute&,const int,const ParticleIndex*,const bool,char*) const
 {
 #if 0
     assert(attribute.attributeIndex>=0 && attribute.attributeIndex<(int)attributes.size());
@@ -297,8 +296,8 @@ dataInternalMultiple(const ParticleAttribute& attribute,const int indexCount,
 }
 
 void ParticlesSimpleInterleave::
-dataAsFloat(const ParticleAttribute& attribute,const int indexCount,
-    const ParticleIndex* particleIndices,const bool sorted,float* values) const
+dataAsFloat(const ParticleAttribute&,const int,
+    const ParticleIndex*,const bool,float*) const
 {
 #if 0
     assert(attribute.attributeIndex>=0 && attribute.attributeIndex<(int)attributes.size());

--- a/src/lib/io/BGEO.cpp
+++ b/src/lib/io/BGEO.cpp
@@ -237,7 +237,7 @@ bool writeBGEO(const char* filename,const ParticlesData& p,const bool compressed
                 int houdiniType=4;
                 unsigned short size=attr.count;
                 const std::vector<std::string>& indexTable=p.indexedStrs(attr);
-                int numIndexes=indexTable.size();
+                int numIndexes=static_cast<int>(indexTable.size());
                 write<BIGEND>(*output,size,houdiniType,numIndexes);
                 for(int i=0;i<numIndexes;i++)
                     writeHoudiniStr(*output,indexTable[i]);

--- a/src/lib/io/BGEO.cpp
+++ b/src/lib/io/BGEO.cpp
@@ -235,7 +235,7 @@ bool writeBGEO(const char* filename,const ParticlesData& p,const bool compressed
             writeHoudiniStr(*output,attr.name);
             if(attr.type==INDEXEDSTR){
                 int houdiniType=4;
-                unsigned short size=attr.count;
+                unsigned short size=static_cast<unsigned short>(attr.count);
                 const std::vector<std::string>& indexTable=p.indexedStrs(attr);
                 int numIndexes=static_cast<int>(indexTable.size());
                 write<BIGEND>(*output,size,houdiniType,numIndexes);
@@ -250,7 +250,7 @@ bool writeBGEO(const char* filename,const ParticlesData& p,const bool compressed
                     case INDEXEDSTR:
                     case NONE: assert(false);houdiniType=0;break;
                 }
-                unsigned short size=attr.count;
+                unsigned short size=static_cast<unsigned short>(attr.count);
                 write<BIGEND>(*output,size,houdiniType);
                 for(int i=0;i<attr.count;i++){
                     int defaultValue=0;
@@ -310,7 +310,14 @@ bool writeBGEO(const char* filename,const ParticlesData& p,const bool compressed
 
     // Write extra
     write<BIGEND>(*output,(char)0x00);
+#ifdef _MSC_VER  
+	#pragma warning (push)  
+	#pragma warning (disable : 4310 )  // suppress the warning for 0xff being truncated to 0x7f (max value of a signed char)
+#endif  
     write<BIGEND>(*output,(char)0xff);
+#ifdef _MSC_VER  
+	#pragma warning (pop)  
+#endif  
 
     // success
     return true;

--- a/src/lib/io/BIN.cpp
+++ b/src/lib/io/BIN.cpp
@@ -236,15 +236,19 @@ bool writeBIN(const char* filename,const ParticlesData& p,const bool /*compresse
     for(int i = 0; i < 250; i++)
     {header.fluidName[i] = 0;}
     string str = "partioExport";
-    str.copy(header.fluidName,15,0);  //  fluid name
+#ifdef PARTIO_WIN32
+	str._Copy_s(header.fluidName,15,0);  //  fluid name
+#else
+	str.copy(header.fluidName,15,0);  //  fluid name
+#endif
     header.framePerSecond = 24; // frames per second
     header.scaleScene = 1.0; // scene scale
     header.fluidType = 9; // fluid type
     header.version =  11; // version (11 is most current)
     header.frameNumber =  1; // frame number
-    header.elapsedSimulationTime = 0.0416666; //   time elapsed (in seconds)
+    header.elapsedSimulationTime = 0.0416666f; //   time elapsed (in seconds)
     header.numParticles = p.numParticles(); // number of particles
-    header.radius = 0.1; // radius of emitter
+    header.radius = 0.1f; // radius of emitter
     header.pressure[0] = 1.0; // max, min, and avg pressure
     header.pressure[1] = 1.0;
     header.pressure[2] = 1.0;

--- a/src/lib/io/GEO.cpp
+++ b/src/lib/io/GEO.cpp
@@ -224,7 +224,7 @@ ParticlesDataMutable* readGEO(const char* filename,const bool headersOnly)
 
 
 template<class T>
-void writeType(ostream& output,const ParticlesData& p,const ParticleAttribute& attrib,
+void writeType(ostream& output,const ParticlesData&,const ParticleAttribute& attrib,
     const ParticleAccessor& accessor,const ParticlesData::const_iterator& iterator)
 {
     const T* data=accessor.raw<T>(iterator);

--- a/src/lib/io/PDA.cpp
+++ b/src/lib/io/PDA.cpp
@@ -87,9 +87,9 @@ ParticlesDataMutable* readPDA(const char* filename,const bool headersOnly)
 
         if(word=="V"){
             attrs.push_back(simple->addAttribute(attrNames[index].c_str(),Partio::VECTOR,3));
-        }else if("R"){
+        }else if(word=="R"){
             attrs.push_back(simple->addAttribute(attrNames[index].c_str(),Partio::FLOAT,1));
-        }else if("I"){
+        }else if(word=="I"){
             attrs.push_back(simple->addAttribute(attrNames[index].c_str(),Partio::INT,1));
         }
 

--- a/src/lib/io/PRT.cpp
+++ b/src/lib/io/PRT.cpp
@@ -327,7 +327,7 @@ ParticlesDataMutable* readPRT(const char* filename,const bool headersOnly)
 		}
 	}
     
-    delete prt_buf;
+    delete[] prt_buf;
     
     if (inflateEnd( &z ) != Z_OK) {
         std::cerr<<"Zlib inflateEnd error"<<std::endl;

--- a/src/lib/io/PTC.cpp
+++ b/src/lib/io/PTC.cpp
@@ -32,7 +32,9 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 */
-#define _USE_MATH_DEFINES
+#ifndef _USE_MATH_DEFINES
+    #define _USE_MATH_DEFINES
+#endif
 #include <cmath>
 
 #include "../Partio.h"
@@ -209,9 +211,9 @@ ParticlesDataMutable* readPTC(const char* filename,const bool headersOnly)
 	     float nz = (float)z / 65535.0f;
 	     norm[2] = 2.0f * nz - 1.0f;
 	     float fphi = (float)phi / 65535.0f;
-	     fphi = 2.0 * M_PI * (fphi - 0.5);
+	     fphi = 2.0f * static_cast<float>(M_PI) * (fphi - 0.5f);
 	     //assert(-M_PI-0.0001 <= fphi && fphi <= M_PI+0.0001);
-	     double rxy = sqrt(1.0 - norm[2]*norm[2]);
+	     float rxy = sqrt(1.0f - norm[2]*norm[2]);
 	     norm[0] = rxy * sin(fphi);
 	     norm[1] = rxy * cos(fphi);
 	} else {
@@ -285,7 +287,7 @@ bool writePTC(const char* filename,const ParticlesData& p,const bool compressed)
             else write<LITEND>(*output,(float)0);
     }
     // eye-to-screen
-    const float foo[4][4]={{1.8,0,0,0}, {0,2.41,0,0}, {0,0,1,1}, {0,0,-.1,0}};
+    const float foo[4][4]={{1.8f,0,0,0}, {0,2.41f,0,0}, {0,0,1,1}, {0,0,-.1f,0}};
     for(int i=0;i<4;i++) for(int j=0;j<4;j++){
             write<LITEND>(*output,foo[i][j]);
     }

--- a/src/lib/io/PTS.cpp
+++ b/src/lib/io/PTS.cpp
@@ -89,14 +89,23 @@ ParticlesDataMutable* readPTS(const char* filename,const bool headersOnly)
 	input->getline(line,1024);
     input->getline(line,1024);
     int valcount = 0;
-    char * pch = strtok( line, "\t " );
+#ifdef PARTIO_WIN32
+	char * nextLine;
+    char * pch = strtok_s( line, "\t ", &nextLine );
+#else
+	char * pch = strtok( line, "\t " );
+#endif
     while ( pch )
     {
         if ( *pch != 0 && *pch != '\n' )
 		{
             valcount++;
         }
-        pch = strtok( NULL, "\t " );
+#ifdef PARTIO_WIN32
+        pch = strtok_s( NULL, "\t ", &nextLine );
+#else
+		pch = strtok( NULL, "\t " );
+#endif
     }
 
 

--- a/src/lib/io/PTS.cpp
+++ b/src/lib/io/PTS.cpp
@@ -90,7 +90,7 @@ ParticlesDataMutable* readPTS(const char* filename,const bool headersOnly)
     input->getline(line,1024);
     int valcount = 0;
 #ifdef PARTIO_WIN32
-	char * nextLine;
+	char * nextLine = NULL;
     char * pch = strtok_s( line, "\t ", &nextLine );
 #else
 	char * pch = strtok( line, "\t " );

--- a/src/lib/io/PartioEndian.h
+++ b/src/lib/io/PartioEndian.h
@@ -41,12 +41,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 namespace Partio{
 
-#ifdef PartioBIG_ENDIAN
-static const bool big_endian=true;
-#else
-static const bool big_endian=false;
-#endif
-
 template<class T>
 void endianSwap(T& value)
 {
@@ -58,17 +52,29 @@ void endianSwap(T& value)
      }
 }
 
+#ifdef PartioBIG_ENDIAN
 struct BIGEND {
-    template<class T> static void swap(T& x){
-        if(!big_endian) endianSwap(x);
+    template<class T> static void swap(T&){
     }
 };
 
 struct LITEND {
     template<class T> static void swap(T& x){
-        if(big_endian) endianSwap(x);
+        endianSwap(x);
     }
 };
+#else
+struct BIGEND {
+    template<class T> static void swap(T& x){
+        endianSwap(x);
+    }
+};
+
+struct LITEND {
+    template<class T> static void swap(T&){
+    }
+};
+#endif
 
 template<class E,class T> inline void
 read(std::istream& input,T& d)

--- a/src/lib/io/ZIP.cpp
+++ b/src/lib/io/ZIP.cpp
@@ -513,7 +513,7 @@ Find_And_Read_Central_Header()
     std::ios::streamoff read_start=max_comment_size+read_size_before_comment;
     if(read_start>end_position) read_start=end_position;
     istream.seekg(end_position-read_start);
-    char *buf=new char[read_start];
+    char *buf=new char[static_cast<unsigned int>(read_start)];
     if(read_start<=0){std::cerr<<"ZIP: Invalid read buffer size"<<std::endl;return false;}
     istream.read(buf,read_start);
     int found=-1;

--- a/src/lib/io/ZIP.cpp
+++ b/src/lib/io/ZIP.cpp
@@ -298,7 +298,7 @@ public:
         int count=static_cast<int>(istream.gcount());
         total_read+=count;
         return count;}
-    return 1;}
+    }
 
     virtual int underflow()
     {if(gptr() && (gptr()<egptr())) return traits_type::to_int_type(*gptr()); // if we already have data just use it
@@ -310,8 +310,11 @@ public:
     if(num<=0) return EOF;
     return traits_type::to_int_type(*gptr());}
 
-    virtual int overflow(int c=EOF)
+    virtual int overflow(int)
     {assert(false);return EOF;}
+
+	// assignment operator declared and not defined, to suppress warning 4512 for Visual Studio
+	ZipStreambufDecompress& operator=(const ZipStreambufDecompress& _Right);
 
 //#####################################################################
 };
@@ -394,9 +397,12 @@ protected:
     {std::runtime_error("Attempt to read write only ostream");return 0;}
 
     virtual int overflow(int c=EOF)
-    {if(c!=EOF){*pptr()=c;pbump(1);}
+    {if(c!=EOF){*pptr()=static_cast<char>(c);pbump(1);}
     if(process(false)==EOF) return EOF;
     return c;}
+
+	// assignment operator declared and not defined, to suppress warning 4512 for Visual Studio
+	ZipStreambufCompress& operator=(const ZipStreambufCompress& _Right);
 
 //#####################################################################
 };
@@ -467,7 +473,7 @@ ZipFileWriter::
 // Function ZipFileWriter
 //#####################################################################
 std::ostream* ZipFileWriter::
-Add_File(const std::string& filename,const bool binary)
+Add_File(const std::string& filename,const bool)
 {
     files.push_back(new ZipFileHeader(filename));
     return new ZIP_FILE_OSTREAM(files.back(),ostream);
@@ -542,7 +548,7 @@ Find_And_Read_Central_Header()
 //#####################################################################
 // Function Get_File
 //#####################################################################
-std::istream* ZipFileReader::Get_File(const std::string& filename,const bool binary)
+std::istream* ZipFileReader::Get_File(const std::string& filename,const bool)
 {
     std::map<std::string,ZipFileHeader*>::iterator i=filename_to_header.find(filename);
     if(i!=filename_to_header.end()){


### PR DESCRIPTION
Fix Visual Studio W3 & W4 warnings

To check:
PDA.cpp line 90 -> should the comparison be with word?
BGEO.cpp line 313 -> 0xFF is truncated as it is casts to char, should the cast be to an unsigned char?
