### PR TITLE
Fixes to read .bin and .prt files

### DIFF
--- a/src/lib/io/BIN.cpp
+++ b/src/lib/io/BIN.cpp
@@ -73,6 +73,22 @@ typedef struct{
     float emitterScale[3];
 } BIN_HEADER;
 
+typedef struct{
+    int verificationCode;
+    char fluidName[250] ;
+    short version;
+    float scaleScene;
+    int fluidType;
+    float elapsedSimulationTime;
+    int frameNumber;
+    int framePerSecond;
+    int numParticles;
+    float radius;
+    float pressure[3];
+    float speed[3];
+    float temperature[3];
+} BIN_HEADERV6;
+
 
 ParticlesDataMutable* readBIN(const char* filename, const bool headersOnly){
 
@@ -84,7 +100,21 @@ ParticlesDataMutable* readBIN(const char* filename, const bool headersOnly){
     }
 
     BIN_HEADER header;
-    input->read((char*)&header, sizeof(header));
+    input->read((char*)&header, sizeof(BIN_HEADERV6));
+
+    // According to the NextLimit bin_particles_file_format.pdf file
+    if (header.version >= 7)
+    {
+        input->read((char*)&header.emitterPosition, sizeof(header.emitterPosition));
+        input->read((char*)&header.emitterRotation, sizeof(header.emitterRotation));
+        input->read((char*)&header.emitterScale, sizeof(header.emitterScale));
+    }
+
+    // After version 13, we don't know what to do
+    if(header.version > 13){
+        cerr << "Partio: Unknown .bin version : " << header.version << endl;
+        return 0;
+    }
 
     if(BIN_MAGIC != header.verificationCode){
         cerr << "Partio: Magic number '" << hex<<  header.verificationCode << "' of '" << filename << "' doesn't match BIN magic '" << BIN_MAGIC << "'" << endl;
@@ -102,13 +132,17 @@ ParticlesDataMutable* readBIN(const char* filename, const bool headersOnly){
     ParticleAttribute forceAttr;
     forceAttr = simple->addAttribute("force", VECTOR, 3);
     ParticleAttribute vortAttr;
-    vortAttr = simple->addAttribute("vorticity", VECTOR, 3);
+    if (header.version >= 9)
+        vortAttr = simple->addAttribute("vorticity", VECTOR, 3);
     ParticleAttribute normAttr;
-    normAttr = simple->addAttribute("normal", VECTOR, 3);
+    if (header.version >= 3)
+        normAttr = simple->addAttribute("normal", VECTOR, 3);
     ParticleAttribute neighborsAttr;
-    neighborsAttr = simple->addAttribute("neighbors", INT, 1);
+    if (header.version >= 4)
+        neighborsAttr = simple->addAttribute("neighbors", INT, 1);
     ParticleAttribute uvwAttr;
-    uvwAttr = simple->addAttribute("uvw", VECTOR, 3);
+    if (header.version >= 5)
+        uvwAttr = simple->addAttribute("uvw", VECTOR, 3);
     ParticleAttribute ageAttr;
     ageAttr = simple->addAttribute("age", FLOAT, 1);
     ParticleAttribute isoTimeAttr;
@@ -127,7 +161,7 @@ ParticlesDataMutable* readBIN(const char* filename, const bool headersOnly){
     pidAttr = simple->addAttribute("id", INT, 1);
 
     if (!headersOnly)
-	{
+    {
         for(int partIndex = 0; partIndex < simple->numParticles(); partIndex++)
         {
 
@@ -170,32 +204,44 @@ ParticlesDataMutable* readBIN(const char* filename, const bool headersOnly){
             input->read ((char *) &force[2], sizeof(float));
                 simple->dataWrite<float>(forceAttr, partIndex)[2] = (float)force[2];
 
-            input->read ((char *) &vorticity[0], sizeof(float));
-                simple->dataWrite<float>(vortAttr, partIndex)[0] = (float)vorticity[0];
-            input->read ((char *) &vorticity[1], sizeof(float));
-                simple->dataWrite<float>(vortAttr, partIndex)[1] = (float)vorticity[1];
-            input->read ((char *) &vorticity[2], sizeof(float));
-                simple->dataWrite<float>(vortAttr, partIndex)[2] = (float)vorticity[2];
+            if (header.version >= 9)
+            {
+                input->read ((char *) &vorticity[0], sizeof(float));
+                    simple->dataWrite<float>(vortAttr, partIndex)[0] = (float)vorticity[0];
+                input->read ((char *) &vorticity[1], sizeof(float));
+                    simple->dataWrite<float>(vortAttr, partIndex)[1] = (float)vorticity[1];
+                input->read ((char *) &vorticity[2], sizeof(float));
+                    simple->dataWrite<float>(vortAttr, partIndex)[2] = (float)vorticity[2];
+            }
 
-            input->read ((char *) &normal[0], sizeof(float));
-                simple->dataWrite<float>(normAttr, partIndex)[0] = (float)normal[0];
-            input->read ((char *) &normal[1], sizeof(float));
-                simple->dataWrite<float>(normAttr, partIndex)[1] = (float)normal[1];
-            input->read ((char *) &normal[2], sizeof(float));
-                simple->dataWrite<float>(normAttr, partIndex)[2] = (float)normal[2];
+            if (header.version >= 3)
+            {
+                input->read ((char *) &normal[0], sizeof(float));
+                    simple->dataWrite<float>(normAttr, partIndex)[0] = (float)normal[0];
+                input->read ((char *) &normal[1], sizeof(float));
+                    simple->dataWrite<float>(normAttr, partIndex)[1] = (float)normal[1];
+                input->read ((char *) &normal[2], sizeof(float));
+                    simple->dataWrite<float>(normAttr, partIndex)[2] = (float)normal[2];
+                }
 
+            if (header.version >= 4)
+            {
+                input->read ((char *) &neighbors, sizeof (int));
+                    simple->dataWrite<int>(neighborsAttr, partIndex)[0] = (int)neighbors;
+            }
 
-            input->read ((char *) &neighbors, sizeof (int));
-                simple->dataWrite<int>(neighborsAttr, partIndex)[0] = (int)neighbors;
+            if (header.version >= 5)
+            {
+                input->read ((char *) &uvw[0], sizeof(float));
+                    simple->dataWrite<float>(uvwAttr, partIndex)[0] = (float)uvw[0];
+                input->read ((char *) &uvw[1], sizeof(float));
+                    simple->dataWrite<float>(uvwAttr, partIndex)[1] = (float)uvw[1];
+                input->read ((char *) &uvw[2], sizeof(float));
+                    simple->dataWrite<float>(uvwAttr, partIndex)[2] = (float)uvw[2];
 
-            input->read ((char *) &uvw[0], sizeof(float));
-                simple->dataWrite<float>(uvwAttr, partIndex)[0] = (float)uvw[0];
-            input->read ((char *) &uvw[1], sizeof(float));
-                simple->dataWrite<float>(uvwAttr, partIndex)[1] = (float)uvw[1];
-            input->read ((char *) &uvw[2], sizeof(float));
-                simple->dataWrite<float>(uvwAttr, partIndex)[2] = (float)uvw[2];
+                input->read ((char *) &infoBits, sizeof(infoBits));
+            }
 
-            input->read ((char *) &infoBits, sizeof(infoBits));
             // don't  do anything with this..
             input->read ((char *) &age, sizeof(age));
                 simple->dataWrite<float>(ageAttr, partIndex)[0] = (float)age;
@@ -211,8 +257,18 @@ ParticlesDataMutable* readBIN(const char* filename, const bool headersOnly){
                 simple->dataWrite<float>(massAttr, partIndex)[0] = (float)mass;
             input->read ((char *) &temperature, sizeof(temperature));
                 simple->dataWrite<float>(tempAttr, partIndex)[0] = (float)temperature;
-            input->read ((char *) &pid, sizeof(pid));
-                simple->dataWrite<int>(pidAttr, partIndex)[0] = (int)pid;
+
+            // pid
+            if (header.version < 12)
+                input->read ((char *) &pid, sizeof(pid));
+            else
+            {
+                // Warning, cast the id on 32 bits here
+                uint64_t pid64;
+                input->read ((char*) &pid64, sizeof(pid64));
+                pid = (int)pid64;
+            }
+            simple->dataWrite<int>(pidAttr, partIndex)[0] = (int)pid;
         }
     }
 

--- a/src/lib/io/PRT.cpp
+++ b/src/lib/io/PRT.cpp
@@ -116,6 +116,10 @@ static bool read_buffer(std::istream& is, z_stream& z, char* in_buf, void* p, si
             std::cerr<<"Zlib error "<<z.msg<<std::endl;;
             return false;
         }
+        if (ret == Z_STREAM_END && z.avail_out > 0) {
+            std::cerr<<"Truncated prt file  "<<std::endl;;
+            return false;
+        }
     }
     return true;
 }

--- a/src/lib/io/PRT.cpp
+++ b/src/lib/io/PRT.cpp
@@ -224,7 +224,7 @@ ParticlesDataMutable* readPRT(const char* filename,const bool headersOnly)
         }
         
         // The size of the particle is determined from the channel with largest offset. The channels are not required to be listed in order.
-        particleSize = (std::max)( particleSize, chans.back().offset + sizes[type] );
+        particleSize = (std::max)( particleSize, chans.back().offset + sizes[ch.type] );
         
         // The channel entry might have more data in other PRT versions.
         if ((unsigned)channelsize > sizeof(Channel))


### PR DESCRIPTION
According to the RealFlow file format pdf, read the .bin format fields
using the file version number. Up to version 13. Fails for the next versions.