### PR TITLE
Fixed build failing when building with zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ ENDIF(ZLIB_FOUND)
 
 ## Make modules able to see partio library
 # Setup environment variable to link partio
-SET( PARTIO_LIBRARIES ${ZLIB_LIBRARY} partio )
+SET( PARTIO_LIBRARIES partio ${ZLIB_LIBRARY} )
 # make it so partio can be found
 INCLUDE_DIRECTORIES( ${CMAKE_SOURCE_DIR}/src/lib )
 


### PR DESCRIPTION
When building with zlib, the partio library ends up depending on zlib but is linked in the incorrect order, resulting in a build error.
This pull request changes the order in which libraries are linked to fix this issue.

Fixes #42 