### PR TITLE
Fixed FXSOFT-802: partio's static lib causes multiple global static d…

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -33,7 +33,7 @@
 
 FILE(GLOB io_cpp "io/*.cpp")
 FILE(GLOB core_cpp "core/*.cpp")
-ADD_LIBRARY (partio ${io_cpp} ${core_cpp})
+ADD_LIBRARY (partio SHARED ${io_cpp} ${core_cpp})
 
 FILE(GLOB public_includes "*.h")
 


### PR DESCRIPTION
…ata destruction & maybe crash on exit

Now installs a dynamic libpartio.so instead of libpartio.a.

Developers will need to 'make clean' or remove the obsolete .a file
when rebuilding their partio workspace.