### PR TITLE
Fix link against specific python version on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ IF(WIN32)
 ELSE(WIN32)
   ADD_COMPILE_OPTIONS (-Wextra -Wno-unused-parameter)
 ENDIF(WIN32)
-IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+IF(APPLE)
   set (CMAKE_SHARED_LINKER_FLAGS "-undefined dynamic_lookup")
 ENDIF()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,9 @@ IF(WIN32)
 ELSE(WIN32)
   ADD_COMPILE_OPTIONS (-Wextra -Wno-unused-parameter)
 ENDIF(WIN32)
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set (CMAKE_SHARED_LINKER_FLAGS "-undefined dynamic_lookup")
+ENDIF()
 
 ## Choose build options
 # Disney specific method of choosing variant


### PR DESCRIPTION
Partio currently has explicit Python version links. This makes it hard to upgrade the hombres formula at this point (https://github.com/Homebrew/homebrew-core/pull/38921). The patch should fix it.

[Here is the explanation](http://blog.tim-smith.us/2015/09/python-extension-modules-os-x/) about why it would be good if you could use the -undefined dynamic_lookup flag while linking under OS X: