### PR TITLE
Add CI support, along with some fixes for Windows.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: C/C++ CI
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-linux-unix:
+    strategy:
+      matrix:
+        os: [ubuntu]
+        config: [Debug, Release]
+    name: ${{matrix.os}}-${{matrix.config}}
+    runs-on: ${{matrix.os}}-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: sudo apt update && sudo apt install -y zlib1g-dev freeglut3-dev libgtest-dev
+    - name: CMake configure
+      run: cmake -G "Unix Makefiles" -DPARTIO_GTEST_ENABLED=ON -DCMAKE_BUILD_TYPE=${{matrix.config}} .
+    - name: Build
+      run: cmake --build .
+
+  build-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        architecture: [x64]
+        config: [Debug, Release]
+    name: windows-${{matrix.architecture}}-${{matrix.config}}
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get ZLIB
+      run: vcpkg install zlib:${{matrix.architecture}}-windows
+    - name: Get GLUT
+      run: vcpkg install freeglut:${{matrix.architecture}}-windows
+    - name: Get OpenGL
+      run: vcpkg install opengl:${{matrix.architecture}}-windows
+    - name: Get gtest
+      run: vcpkg install gtest:${{matrix.architecture}}-windows
+    - name: CMake configure
+      run: cmake "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" -DBUILD_SHARED_LIBS=OFF -DPARTIO_GTEST_ENABLED=ON -A ${{matrix.architecture}} .
+    - name: Build
+      run: cmake --build . --config ${{matrix.config}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,13 @@ cmake_minimum_required(VERSION 3.15.0)
 project(partio LANGUAGES CXX)
 
 option(BUILD_SHARED_LIBS "Enabled shared libraries" ON)
-option(GTEST_ENABLED "Enable GTest for tests" OFF)
+option(PARTIO_GTEST_ENABLED "Enable GTest for tests" OFF)
+
+if(WIN32)
+    option(PARTIO_USE_GLVND "Use GLVND for OpenGL" OFF)
+else()
+    option(PARTIO_USE_GLVND "Use GLVND for OpenGL" ON)
+endif()
 
 # Enable C++11
 if (DEFINED ENV{CXXFLAGS_STD})
@@ -119,13 +125,13 @@ endif()
 # Make modules able to see partio library
 set(PARTIO_LIBRARIES partio ${ZLIB_LIBRARY})
 
-if (${GTEST_ENABLED})
+if (${PARTIO_GTEST_ENABLED})
     set($GEST_LOCATION "/usr" CACHE STRING "gtest installation prefix")
     set(GTEST_INCLUDE_PATH ${GTEST_LOCATION}/include)
     set(GTEST_LIBDIR ${CMAKE_INSTALL_LIBDIR})
     set(GTEST_LINK_PATH ${GTEST_LOCATION}/${GTEST_LIBDIR} CACHE STRING "gtest library directory")
 endif()
-
+ 
 ## Traverse subdirectories
 add_subdirectory(src/lib)
 add_subdirectory(src/tools)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -43,11 +43,7 @@ target_include_directories(partio
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 if (ZLIB_FOUND)
-    target_include_directories(partio
-        PUBLIC
-            $<INSTALL_INTERFACE:${ZLIB_INCLUDE_DIR}>
-            $<BUILD_INTERFACE:${ZLIB_INCLUDE_DIR}>)
-    target_link_libraries(partio PUBLIC ${ZLIB_LIBRARY})
+    target_link_libraries(partio PUBLIC ZLIB::ZLIB)
 endif()
 
 install(TARGETS partio DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -33,21 +33,22 @@
 
 set(CMAKE_INSTALL_PARTIO_TESTDIR ${CMAKE_INSTALL_DATAROOTDIR}/partio/test)
 find_library(GTEST_LIB gtest HINTS ${GTEST_LINK_PATH})
-
+ 
 if ("${GTEST_LIB}" STREQUAL "GTEST_LIB-NOTFOUND")
     message(STATUS "${GTEST_LIB} not found in ${GTEST_LINK_PATH}, tests disabled")
 else()
-    link_directories(${CMAKE_BINARY_DIR}/src/lib ${GTEST_LINK_PATH})
-
+ 
     foreach(item testiterator testio testcache testclonecopy testcluster teststr makecircle makeline testkdtree testmerge)
         add_executable(${item} "${item}.cpp")
         target_include_directories(${item} PRIVATE ${GTEST_INCLUDE_PATH})
         target_link_libraries(
             ${item} ${PARTIO_LIBRARIES} ${GTEST_LIB} Threads::Threads)
         target_compile_definitions(${item} PRIVATE -DPARTIO_DATA_DIR="${PROJECT_SOURCE_DIR}/src/data")
+        target_link_directories(${item} PRIVATE ${GTEST_LINK_PATH})
         install(TARGETS ${item} DESTINATION ${CMAKE_INSTALL_PARTIO_TESTDIR})
         add_test(NAME ${item} COMMAND ${item})
     endforeach(item)
 
     install(PROGRAMS testpartjson.py DESTINATION ${CMAKE_INSTALL_PARTIO_TESTDIR} RENAME testpartjson)
 endif()
+install(PROGRAMS testpartjson.py DESTINATION ${CMAKE_INSTALL_PARTIO_TESTDIR} RENAME testpartjson)

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -41,9 +41,14 @@ if (GLUT_FOUND AND OPENGL_FOUND)
         PRIVATE
         ${PARTIO_LIBRARIES}
         GLUT::GLUT
-        OpenGL::OpenGL
         OpenGL::GLU
     )
+    if(PARTIO_USE_GLVND)
+        target_link_libraries(partview PRIVATE OpenGL::OpenGL)
+    else()
+        target_link_libraries(partview PRIVATE OpenGL::GL)
+    endif()
+    
     install(TARGETS partview DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 


### PR DESCRIPTION
Other changes:

* Replace `OpenGL::OpenGL` with `OpenGL::GL`, as `OpenGL::OpenGL` doesn't work on Windows.
* Use `ZLIB::ZLIB` to reference ZLIB, and add it to the public dependencies.
* Disable shared libraries by default. The library has no symbol visibility set, so on Visual C++ it will not produce a library by default as there are no symbols.

I'm not 100% certain about the `OpenGL::GL` change, and I can easily make that conditional based on Windows if that's preferred, but I don't see use of EGL either so ... it's unclear if `OpenGL::OpenGL` is really needed. For the shared library, the correct fix would be to export all symbols that could be used by clients, but I'm not sure which ones those are so I'll rather err on the side of caution here.