### PR TITLE
Add PARTIO_BUILD_SHARED_LIBS.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,6 @@ jobs:
     - name: Get gtest
       run: vcpkg install gtest:${{matrix.architecture}}-windows
     - name: CMake configure
-      run: cmake "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" -DBUILD_SHARED_LIBS=OFF -DPARTIO_GTEST_ENABLED=ON -A ${{matrix.architecture}} .
+      run: cmake "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" -DPARTIO_GTEST_ENABLED=ON -A ${{matrix.architecture}} .
     - name: Build
       run: cmake --build . --config ${{matrix.config}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,13 +34,14 @@
 cmake_minimum_required(VERSION 3.15.0)
 project(partio LANGUAGES CXX)
 
-option(BUILD_SHARED_LIBS "Enabled shared libraries" ON)
 option(PARTIO_GTEST_ENABLED "Enable GTest for tests" OFF)
 
 if(WIN32)
     option(PARTIO_USE_GLVND "Use GLVND for OpenGL" OFF)
+    option(PARTIO_BUILD_SHARED_LIBS "Enabled shared libraries" OFF)
 else()
     option(PARTIO_USE_GLVND "Use GLVND for OpenGL" ON)
+    option(PARTIO_BUILD_SHARED_LIBS "Enabled shared libraries" ON)
 endif()
 
 # Enable C++11

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -34,7 +34,12 @@
 file(GLOB io_cpp "io/*.cpp")
 file(GLOB core_cpp "core/*.cpp")
 
-add_library(partio ${io_cpp} ${core_cpp})
+if(PARTIO_BUILD_SHARED_LIBS)
+    set(PARTIO_LIBRARY_TYPE SHARED)
+else()
+    set(PARTIO_LIBRARY_TYPE STATIC)
+endif()
+add_library(partio ${PARTIO_LIBRARY_TYPE} ${io_cpp} ${core_cpp})
 set_target_properties(partio PROPERTIES OUTPUT_NAME partio POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(partio


### PR DESCRIPTION
This acts similar to BUILD_SHARED_LIBS, but it's namespaced, and it
is off by default on Windows as partio does not export any symbols
by default.