### PR TITLE
Don't install testpartjson.py unconditionally.

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -51,4 +51,3 @@ else()
 
     install(PROGRAMS testpartjson.py DESTINATION ${CMAKE_INSTALL_PARTIO_TESTDIR} RENAME testpartjson)
 endif()
-install(PROGRAMS testpartjson.py DESTINATION ${CMAKE_INSTALL_PARTIO_TESTDIR} RENAME testpartjson)


### PR DESCRIPTION
This was spotted here: https://github.com/wdas/partio/commit/3d7cf9ecb629a25ea937056e9cfc02664a8a4e60#r44759719 and obviously it shouldn't be installed twice. Not sure how that happened in the first place.

Signed-off-by: Matthäus G. Chajdas <dev@anteru.net>