### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/tests/teststr.cpp
+++ b/src/tests/teststr.cpp
@@ -60,7 +60,7 @@ int main(int argc,char *argv[])
         int alive=p->lookupIndexedStr(stateAttr,"alive");
         int dead=p->lookupIndexedStr(stateAttr,"dead");
         int zombie=p->lookupIndexedStr(stateAttr,"zombie");
-        int states[]={alive,dead,zombie}; // every ith particle should be asigned these in order
+        int states[]={alive,dead,zombie}; // every ith particle should be assigned these in order
         if(alive == -1 || dead == -1 || zombie == -1){ std::cerr<<"don't have tokens I expect!"<<std::endl;}
 
         for(int i=0;i<p->numParticles();i++){

--- a/src/tools/partjson.py
+++ b/src/tools/partjson.py
@@ -44,7 +44,7 @@ def toJson(particleSet):
                                       'value': particleSet.getFixed(attr),
                                      }
 
-        # Convert indexed string attributse
+        # Convert indexed string attributes
         if attr.type == partio.INDEXEDSTR:
             fixedIndexedStrings[attr.name] = particleSet.fixedIndexedStrs(attr)
 
@@ -62,7 +62,7 @@ def toJson(particleSet):
         attrs.append(attr)
         attributes[attr.name] = {'type': attr.type, 'count': attr.count }
 
-        # Convert indexed string attributse
+        # Convert indexed string attributes
         if attr.type == partio.INDEXEDSTR:
             indexedStrings[attr.name] = particleSet.indexedStrs(attr)
 


### PR DESCRIPTION
There are small typos in:
- src/tests/teststr.cpp
- src/tools/partjson.py

Fixes:
- Should read `attributes` rather than `attributse`.
- Should read `assigned` rather than `asigned`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md