### PR TITLE
[py] fix error: cast from 'void*' to 'long unsigned int' loses precision

### DIFF
--- a/src/py/partio.i
+++ b/src/py/partio.i
@@ -465,7 +465,7 @@ public:
 
     %feature("autodoc");
     %feature("docstring","Workaround to get the address to the ptr to help with interop python binding");
-    unsigned long ptr() const { return (unsigned long)(void*)self; }
+    unsigned long long ptr() const { return (unsigned long long)(void*)self; }
 }
 
 %extend ParticlesInfo {


### PR DESCRIPTION
Closes #98