### PR TITLE
Possible memory leak, in theory.

### DIFF
--- a/src/lib/io/ZIP.cpp
+++ b/src/lib/io/ZIP.cpp
@@ -520,9 +520,9 @@ Find_And_Read_Central_Header()
     unsigned int read_size_before_comment=22;
     std::streamoff read_start=max_comment_size+read_size_before_comment;
     if(read_start>end_position) read_start=end_position;
+    if(read_start<=0){std::cerr<<"ZIP: Invalid read buffer size"<<std::endl;return false;}
     istream.seekg(end_position-read_start);
     char *buf=new char[static_cast<unsigned int>(read_start)];
-    if(read_start<=0){std::cerr<<"ZIP: Invalid read buffer size"<<std::endl;return false;}
     istream.read(buf,read_start);
     int found=-1;
     for(unsigned int i=0;i<read_start-3;i++){


### PR DESCRIPTION
Hi!
### Long story short:
I played around with [CppCheck](https://cppcheck.sourceforge.io/) which pointed out places in code where problems may arise. \
Out of them I think this one is fairly straight forward as it also closes #63.
### Argument for validity:
- A 0 byte stream should make it such that buf receives an empty array that seems to [require deletion](https://cplusplus.com/forum/general/72537/)
### Argument against:
- It is unlikely to be used on an empty stream.
### Arguments for the fix:
- It respects the spirit of checking that `read_start` is greater than `0`.
- It moves the check for `read_start` right after its last assignation and before its first use.
### Less relevant information
CppCheck also pointed out other things, among false positives, that I am not confident I can alter in a useful manner. \
Here are the commands to replicate my results: (it runs for a few minutes)\
`cppcheck --check-level=exhaustive --force --output-file=flagged_partio.txt partio` \
`less -R flagged_partio.txt`